### PR TITLE
Refactor to track token's range and use it in Parser

### DIFF
--- a/__tests__/BufferStream_test.re
+++ b/__tests__/BufferStream_test.re
@@ -6,32 +6,25 @@ let it = test;
 describe("BufferStream", () => {
   describe("basic LazyStream wrapping", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("correctly iterates values from a producer function, imitating the passed LazyStream", () => {
       let testStream = from(LazyStream.from([@bs] () => Some(1)));
-
-      expect([ next(testStream), next(testStream) ])
-        |> toEqual([
-          Some(1),
-          Some(1)
-        ]);
+      expect((next(testStream), next(testStream))) == (Some(1), Some(1));
     });
   });
 
   describe("buffer & put", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("buffers an element to the end of a buffer", () => {
       let testStream = from(LazyStream.from([@bs] () => Some(1)));
+
       buffer(42, testStream);
       bufferOption(Some(41), testStream);
 
-      expect([ next(testStream), next(testStream), next(testStream) ])
-        |> toEqual([
-          Some(42),
-          Some(41),
-          Some(1)
-        ]);
+      expect((next(testStream), next(testStream), next(testStream))) == (Some(42), Some(41), Some(1));
     });
 
     it("puts an element at the beginning of a buffer", () => {
@@ -39,12 +32,7 @@ describe("BufferStream", () => {
       put(42, testStream);
       putOption(Some(41), testStream);
 
-      expect([ next(testStream), next(testStream), next(testStream) ])
-        |> toEqual([
-          Some(41),
-          Some(42),
-          Some(1)
-        ]);
+      expect((next(testStream), next(testStream), next(testStream))) == (Some(41), Some(42), Some(1));
     });
   });
 });

--- a/__tests__/Input_test.re
+++ b/__tests__/Input_test.re
@@ -17,7 +17,7 @@ describe("Input", () => {
       Char('l'),
       Char('l'),
       Char('o')
-    |]) |> toBe(true);
+    |]) |> toBe(true)
   });
 
   it("correctly interleaves interpolations inbetween strings", () => {
@@ -34,11 +34,11 @@ describe("Input", () => {
         Interpolation(interpolationValueB),
         Char('1'),
         Char('2')
-      |]);
+      |])
   });
 
   it("throws when number of interpolations is invalid", () => {
     expect(() => Input.input([| "abc", "def" |], [||]))
-      |> toThrowMessage("Expected no of interpolations to equal no of strings - 1. The input is expected to be strings interleaved by the second interpolations array!");
+      |> toThrowMessage("Expected no of interpolations to equal no of strings - 1. The input is expected to be strings interleaved by the second interpolations array!")
   });
 });

--- a/__tests__/LazyStream_test.re
+++ b/__tests__/LazyStream_test.re
@@ -82,4 +82,24 @@ describe("LazyStream", () => {
 
     expect(toArray(testStream)) |> toEqual([| 1, 2, 3, 4, 5 |]);
   });
+
+  it("allows withSideeffect to wrap a stream and call a function on each emission", () => {
+    let index = ref(0);
+    let values = ref([]);
+
+    let testStream = from([@bs] () => {
+      if (index^ < 5) {
+        index := index^ + 1;
+        Some(index^)
+      } else {
+        None
+      }
+    }) |> withSideeffect([@bs] (value) => {
+      values := [value, ...values^];
+    });
+
+    ignore(toArray(testStream));
+
+    expect(values^) |> toEqual([ 5, 4, 3, 2, 1 ]);
+  });
 });

--- a/__tests__/Lexer_test.re
+++ b/__tests__/Lexer_test.re
@@ -15,37 +15,39 @@ let tokenise = (cssString: string): array(token) => {
 describe("Lexer", () => {
   describe("Single char tokens", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("tokenises single chars correctly", () => {
-      expect(tokenise("{}[]()!=:;+&>*~,|$") == [|
-        Token(Brace(Opening), 1),
-        Token(Brace(Closing), 1),
-        Token(Bracket(OpeningSeparated), 1),
-        Token(Bracket(Closing), 1),
-        Token(Paren(OpeningSeparated), 1),
-        Token(Paren(Closing), 1),
-        Token(Exclamation, 1),
-        Token(Equal, 1),
-        Token(Colon, 1),
-        Token(Semicolon, 1),
-        Token(Plus, 1),
-        Token(Ampersand, 1),
-        Token(Arrow, 1),
-        Token(Asterisk, 1),
-        Token(Tilde, 1),
-        Token(Comma, 1),
-        Token(Pipe, 1),
-        Token(Dollar, 1)
-      |]) |> toBe(true);
+      expect(tokenise("{}[]()!=:;+&>*~,|$")) == [|
+        Token(Brace(Opening), (1, 1), (1, 1)),
+        Token(Brace(Closing), (1, 2), (1, 2)),
+        Token(Bracket(Opening), (1, 3), (1, 3)),
+        Token(Bracket(Closing), (1, 4), (1, 4)),
+        Token(Paren(Opening), (1, 5), (1, 5)),
+        Token(Paren(Closing), (1, 6), (1, 6)),
+        Token(Exclamation, (1, 7), (1, 7)),
+        Token(Equal, (1, 8), (1, 8)),
+        Token(Colon, (1, 9), (1, 9)),
+        Token(Semicolon, (1, 10), (1, 10)),
+        Token(Plus, (1, 11), (1, 11)),
+        Token(Ampersand, (1, 12), (1, 12)),
+        Token(Arrow, (1, 13), (1, 13)),
+        Token(Asterisk, (1, 14), (1, 14)),
+        Token(Tilde, (1, 15), (1, 15)),
+        Token(Comma, (1, 16), (1, 16)),
+        Token(Pipe, (1, 17), (1, 17)),
+        Token(Dollar, (1, 18), (1, 18))
+      |];
     });
 
     it("skips over whitespace-chars counting newlines", () => {
-      expect(tokenise("\t\r{   }\n{   }") == [|
-        Token(Brace(Opening), 1),
-        Token(Brace(Closing), 1),
-        Token(Brace(Opening), 2),
-        Token(Brace(Closing), 2)
-      |]) |> toBe(true);
+      expect(tokenise("\t\r{   }\n{   }   test")) == [|
+        Token(Brace(Opening), (1, 3), (1, 3)),
+        Token(Brace(Closing), (1, 7), (1, 7)),
+        Token(Brace(Opening), (2, 1), (2, 1)),
+        Token(Brace(Closing), (2, 5), (2, 5)),
+        Token(Word("test"), (2, 9), (2, 12))
+      |];
     });
 
     it("throws when unexpected tokens are encountered", () => {
@@ -55,96 +57,98 @@ describe("Lexer", () => {
 
   describe("Words & At-Words", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("tokenises words correctly", () => {
-      expect(tokenise("property #id .class_name 10% 10px hello-world") == [|
-        Token(Word("property"), 1),
-        Token(Word("#id"), 1),
-        Token(Word(".class_name"), 1),
-        Token(Word("10%"), 1),
-        Token(Word("10px"), 1),
-        Token(Word("hello-world"), 1)
-      |]) |> toBe(true);
+      expect(tokenise("property #id .class_name 10% 10px hello-world")) == [|
+        Token(Word("property"), (1, 1), (1, 8)),
+        Token(Word("#id"), (1, 10), (1, 12)),
+        Token(Word(".class_name"), (1, 14), (1, 24)),
+        Token(Word("10%"), (1, 26), (1, 28)),
+        Token(Word("10px"), (1, 30), (1, 33)),
+        Token(Word("hello-world"), (1, 35), (1, 45))
+      |];
     });
 
     it("tokenises words containing escaped characters correctly", () => {
-      expect(tokenise("pro\\p\\erty\\0024") == [|
-        Token(Word("pro\\p\\erty\\0024"), 1)
-      |]) |> toBe(true);
+      expect(tokenise("pro\\p\\erty\\0024")) == [|
+        Token(Word("pro\\p\\erty\\0024"), (1, 1), (1, 15))
+      |];
     });
 
     it("tokenises words starting with escaped characters correctly", () => {
-      expect(tokenise("\\property") == [|
-        Token(Word("\\property"), 1)
-      |]) |> toBe(true);
+      expect(tokenise("\\property")) == [|
+        Token(Word("\\property"), (1, 1), (1, 9))
+      |];
     });
 
     it("tokenises at-words correctly", () => {
-      expect(tokenise("@media") == [|
-        Token(AtWord("@media"), 1)
-      |]) |> toEqual(true);
+      expect(tokenise("@media")) == [|
+        Token(AtWord("@media"), (1, 1), (1, 6))
+      |];
     });
   });
 
   describe("Multiline Comments", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("ignores multiline comments", () => {
       expect(tokenise("/* comment */")) |> toEqual([||]);
     });
 
     it("keeps counting newlines in comments", () => {
-      expect(tokenise("/* comment \n */;") == [|
-        Token(Semicolon, 2)
-      |]) |> toBe(true);
+      expect(tokenise("/* comment \n */;")) == [|
+        Token(Semicolon, (2, 4), (2, 4))
+      |];
     });
   });
 
   describe("Interpolations", () => {
     open Expect;
+    open! Expect.Operators;
+
     let interpolationValue = create_interpolation(1);
 
     it("accepts interpolations in the normal lexer loop", () => {
       let lexerStream = lexer(Input.input([| ":", ";" |], [| interpolationValue |]));
       let tokens = LazyStream.toArray(lexerStream);
 
-      expect(tokens == [|
-        Token(Colon, 1),
-        Token(Interpolation(interpolationValue), 1),
-        Token(Semicolon, 1)
-      |]) |> toBe(true);
+      expect(tokens) == [|
+        Token(Colon, (1, 1), (1, 1)),
+        Token(Interpolation(interpolationValue), (1, 2), (1, 2)),
+        Token(Semicolon, (1, 3), (1, 3))
+      |];
     });
 
-    it("combinates words and interpolations using special tokens", () => {
+    it("handled interleaved words and interpolations", () => {
       let interpolationValue = create_interpolation(1);
       let lexerStream = lexer(Input.input([| "hello", "", "world;" |], [| interpolationValue, interpolationValue |]));
       let tokens = LazyStream.toArray(lexerStream);
 
-      expect(tokens == [|
-        Token(Word("hello"), 1),
-        Token(WordCombinator, 1),
-        Token(Interpolation(interpolationValue), 1),
-        Token(WordCombinator, 1),
-        Token(Interpolation(interpolationValue), 1),
-        Token(WordCombinator, 1),
-        Token(Word("world"), 1),
-        Token(Semicolon, 1)
-      |]) |> toBe(true);
+      expect(tokens) == [|
+        Token(Word("hello"), (1, 1), (1, 5)),
+        Token(Interpolation(interpolationValue), (1, 6), (1, 6)),
+        Token(Interpolation(interpolationValue), (1, 7), (1, 7)),
+        Token(Word("world"), (1, 8), (1, 12)),
+        Token(Semicolon, (1, 13), (1, 13))
+      |];
     });
   });
 
   describe("Strings", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("parses single and double quote strings", () => {
-      expect(tokenise({| 'string 1' "string 2" |}) == [|
-        Token(Quote(Single), 1),
-        Token(Str("string 1"), 1),
-        Token(Quote(Single), 1),
-        Token(Quote(Double), 1),
-        Token(Str("string 2"), 1),
-        Token(Quote(Double), 1)
-      |]) |> toBe(true);
+      expect(tokenise({| 'string 1' "string 2" |})) == [|
+        Token(Quote(Single), (1, 2), (1, 2)),
+        Token(Str("string 1"), (1, 3), (1, 10)),
+        Token(Quote(Single), (1, 11), (1, 11)),
+        Token(Quote(Double), (1, 13), (1, 13)),
+        Token(Str("string 2"), (1, 14), (1, 21)),
+        Token(Quote(Double), (1, 22), (1, 22))
+      |];
     });
 
     it("emits interpolations interleaved with strings", () => {
@@ -152,13 +156,13 @@ describe("Lexer", () => {
       let lexerStream = lexer(Input.input([|"'start ", " end'"|], [| interpolationValue |]));
       let tokens = LazyStream.toArray(lexerStream);
 
-      expect(tokens == [|
-        Token(Quote(Single), 1),
-        Token(Str("start "), 1),
-        Token(Interpolation(interpolationValue), 1),
-        Token(Str(" end"), 1),
-        Token(Quote(Single), 1)
-      |]) |> toBe(true);
+      expect(tokens) == [|
+        Token(Quote(Single), (1, 1), (1, 1)),
+        Token(Str("start "), (1, 2), (1, 7)),
+        Token(Interpolation(interpolationValue), (1, 8), (1, 8)),
+        Token(Str(" end"), (1, 9), (1, 12)),
+        Token(Quote(Single), (1, 13), (1, 13))
+      |];
     });
 
     it("throws when no end of string is reached", () => {
@@ -170,36 +174,37 @@ describe("Lexer", () => {
     });
 
     it("accepts escaped content inside strings", () => {
-      expect(tokenise("'newline:\\n'") == [|
-        Token(Quote(Single), 1),
-        Token(Str("newline:\\n"), 1),
-        Token(Quote(Single), 1)
-      |]) |> toBe(true);
+      expect(tokenise("'newline:\\n'")) == [|
+        Token(Quote(Single), (1, 1), (1, 1)),
+        Token(Str("newline:\\n"), (1, 2), (1, 11)),
+        Token(Quote(Single), (1, 12), (1, 12))
+      |];
     });
   });
 
   describe("Unquoted string arguments", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("handles url() argument", () => {
-      expect(tokenise("url(  https://github.com/?v=\"  )") == [|
-        Token(Word("url"), 1),
-        Token(Paren(Opening), 1),
-        Token(Quote(Double), 1),
-        Token(Str("https://github.com/?v=\\\""), 1),
-        Token(Quote(Double), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokenise("url(  https://github.com/?v=\"  )")) == [|
+        Token(Word("url"), (1, 1), (1, 3)),
+        Token(Paren(Opening), (1, 4), (1, 4)),
+        Token(Quote(Double), (1, 7), (1, 7)),
+        Token(Str("https://github.com/?v=\\\""), (1, 7), (1, 29)),
+        Token(Quote(Double), (1, 32), (1, 32)),
+        Token(Paren(Closing), (1, 32), (1, 32))
+      |];
     });
 
     it("handles empty url() argument", () => {
-      expect(tokenise("url(  )") == [|
-        Token(Word("url"), 1),
-        Token(Paren(Opening), 1),
-        Token(Quote(Double), 1),
-        Token(Quote(Double), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokenise("url(  )")) == [|
+        Token(Word("url"), (1, 1), (1, 3)),
+        Token(Paren(Opening), (1, 4), (1, 4)),
+        Token(Quote(Double), (1, 7), (1, 7)),
+        Token(Quote(Double), (1, 7), (1, 7)),
+        Token(Paren(Closing), (1, 7), (1, 7))
+      |];
     });
 
     it("throws when unescaped parentheses in url() argument are found", () => {
@@ -215,16 +220,16 @@ describe("Lexer", () => {
       let lexerStream = lexer(Input.input([|"url(https://twitter.com/", "/)"|], [| username |]));
       let tokens = LazyStream.toArray(lexerStream);
 
-      expect(tokens == [|
-        Token(Word("url"), 1),
-        Token(Paren(Opening), 1),
-        Token(Quote(Double), 1),
-        Token(Str("https://twitter.com/"), 1),
-        Token(Interpolation(username), 1),
-        Token(Str("/"), 1),
-        Token(Quote(Double), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokens) == [|
+        Token(Word("url"), (1, 1), (1, 3)),
+        Token(Paren(Opening), (1, 4), (1, 4)),
+        Token(Quote(Double), (1, 5), (1, 5)),
+        Token(Str("https://twitter.com/"), (1, 5), (1, 24)),
+        Token(Interpolation(username), (1, 25), (1, 25)),
+        Token(Str("/"), (1, 26), (1, 26)),
+        Token(Quote(Double), (1, 27), (1, 27)),
+        Token(Paren(Closing), (1, 27), (1, 27))
+      |];
     });
 
     it("emits interpolations contained after the url() argument", () => {
@@ -232,24 +237,24 @@ describe("Lexer", () => {
       let lexerStream = lexer(Input.input([|"url(https://twitter.com/", ")"|], [| username |]));
       let tokens = LazyStream.toArray(lexerStream);
 
-      expect(tokens == [|
-        Token(Word("url"), 1),
-        Token(Paren(Opening), 1),
-        Token(Quote(Double), 1),
-        Token(Str("https://twitter.com/"), 1),
-        Token(Interpolation(username), 1),
-        Token(Quote(Double), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokens) == [|
+        Token(Word("url"), (1, 1), (1, 3)),
+        Token(Paren(Opening), (1, 4), (1, 4)),
+        Token(Quote(Double), (1, 5), (1, 5)),
+        Token(Str("https://twitter.com/"), (1, 5), (1, 24)),
+        Token(Interpolation(username), (1, 25), (1, 25)),
+        Token(Quote(Double), (1, 26), (1, 26)),
+        Token(Paren(Closing), (1, 26), (1, 26))
+      |];
     });
 
     it("handles calc() argument", () => {
-      expect(tokenise("calc( (50% - 10px) * 2 )") == [|
-        Token(Word("calc"), 1),
-        Token(Paren(Opening), 1),
-        Token(Str("(50% - 10px) * 2 "), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokenise("calc( (50% - 10px) * 2 )")) == [|
+        Token(Word("calc"), (1, 1), (1, 4)),
+        Token(Paren(Opening), (1, 5), (1, 5)),
+        Token(Str(" (50% - 10px) * 2 "), (1, 5), (1, 23)),
+        Token(Paren(Closing), (1, 24), (1, 24))
+      |];
     });
 
     it("throws when no end of argument is reached", () => {
@@ -259,16 +264,17 @@ describe("Lexer", () => {
 
   describe("Quoted string arguments", () => {
     open Expect;
+    open! Expect.Operators;
 
     it("parses strings inside arguments other than url() and calc() correctly", () => {
-      expect(tokenise("partyparrot( 'https://github.com' )") == [|
-        Token(Word("partyparrot"), 1),
-        Token(Paren(Opening), 1),
-        Token(Quote(Single), 1),
-        Token(Str("https://github.com"), 1),
-        Token(Quote(Single), 1),
-        Token(Paren(Closing), 1)
-      |]) |> toBe(true);
+      expect(tokenise("partyparrot( 'https://github.com' )")) == [|
+        Token(Word("partyparrot"), (1, 1), (1, 11)),
+        Token(Paren(Opening), (1, 12), (1, 12)),
+        Token(Quote(Single), (1, 14), (1, 14)),
+        Token(Str("https://github.com"), (1, 15), (1, 32)),
+        Token(Quote(Single), (1, 33), (1, 33)),
+        Token(Paren(Closing), (1, 35), (1, 35))
+      |];
     });
   });
 });

--- a/__tests__/LinkedList_test.re
+++ b/__tests__/LinkedList_test.re
@@ -14,7 +14,7 @@ describe("LinkedList", () => {
 
       [take(testList), take(testList), take(testList)]
         |> expect
-        |> toEqual([ Some("test 1"), Some("test 2"), None ]);
+        |> toEqual([ Some("test 1"), Some("test 2"), None ])
     });
 
     it("updates the size property on a list", () => {
@@ -25,7 +25,7 @@ describe("LinkedList", () => {
       let initialSize = testList.size;
       add("test 3", testList);
 
-      expect([initialSize, testList.size]) |> toEqual([2, 3]);
+      expect([initialSize, testList.size]) |> toEqual([2, 3])
     });
   });
 
@@ -39,7 +39,7 @@ describe("LinkedList", () => {
 
       [take(testList), take(testList), take(testList)]
         |> expect
-        |> toEqual([ Some("test 2"), Some("test 1"), None ]);
+        |> toEqual([ Some("test 2"), Some("test 1"), None ])
     });
 
     it("updates the size property on a list", () => {
@@ -50,7 +50,7 @@ describe("LinkedList", () => {
       let initialSize = testList.size;
       unshift("test 3", testList);
 
-      expect([initialSize, testList.size]) |> toEqual([2, 3]);
+      expect([initialSize, testList.size]) |> toEqual([2, 3])
     });
   });
 
@@ -64,7 +64,7 @@ describe("LinkedList", () => {
 
       [peek(testList), take(testList), take(testList), take(testList)]
         |> expect
-        |> toEqual([ Some("test 1"), Some("test 1"), Some("test 2"), None ]);
+        |> toEqual([ Some("test 1"), Some("test 1"), Some("test 2"), None ])
     });
   });
 
@@ -76,7 +76,7 @@ describe("LinkedList", () => {
       add("test 1", a);
       let b = create();
 
-      expect(concat(a, b)) |> toBe(a);
+      expect(concat(a, b)) |> toBe(a)
     });
 
     it("returns b when a is empty", () => {
@@ -84,7 +84,7 @@ describe("LinkedList", () => {
       let b = create();
       add("test 1", b);
 
-      expect(concat(a, b)) |> toBe(b);
+      expect(concat(a, b)) |> toBe(b)
     });
 
     it("adds b.head to a.tail to concatenate the lists", () => {
@@ -102,7 +102,7 @@ describe("LinkedList", () => {
         Some("test 3"),
         Some("test 4"),
         None
-      |]) |> toBe(true);
+      |]) |> toBe(true)
     });
 
     it("adds b.head to a.tail and sets a.tail to b.tail", () => {
@@ -114,7 +114,7 @@ describe("LinkedList", () => {
       add("test 4", b);
       let con = concat(a, b);
 
-      expect(con.tail == b.tail) |> toBe(true);
+      expect(con.tail == b.tail) |> toBe(true)
     });
   });
 });

--- a/__tests__/PrefixProperty_test.re
+++ b/__tests__/PrefixProperty_test.re
@@ -7,20 +7,13 @@ describe("PrefixProperty", () => {
   describe("prefixForProperty", () => {
     open Expect;
 
-    it("should prefix appearance", () => {
-      expect(prefixForProperty("appearance")) |> toEqual(WebkitMoz);
-    });
-
-    it("should prefix transform", () => {
-      expect(prefixForProperty("transform")) |> toEqual(Webkit);
-    });
-
-    it("should not prefix border", () => {
-      expect(prefixForProperty("border")) |> toEqual(NoPrefix);
-    });
-
-    it("should not prefix color", () => {
-      expect(prefixForProperty("color")) |> toEqual(NoPrefix);
-    });
+    it("should prefix appearance", () =>
+      expect(prefixForProperty("appearance")) |> toEqual(WebkitMoz));
+    it("should prefix transform", () =>
+      expect(prefixForProperty("transform")) |> toEqual(Webkit));
+    it("should not prefix border", () =>
+      expect(prefixForProperty("border")) |> toEqual(NoPrefix));
+    it("should not prefix color", () =>
+      expect(prefixForProperty("color")) |> toEqual(NoPrefix));
   });
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-plugin-minify-dead-code-elimination": "^0.2.0",
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-preset-env": "^1.6.1",
-    "bs-jest": "^0.2.0",
+    "bs-jest": "^0.3.2",
     "bs-loader": "^2.0.0",
     "bs-platform": "^2.1.0",
     "jest": "^21.2.1",

--- a/src/Common.re
+++ b/src/Common.re
@@ -1,6 +1,12 @@
 /* Placeholder type for an interpolation */
 type interpolation;
 
+/* Location range of start and end, signifying (row, column) */
+type locationRange = {
+  startLoc: (int, int),
+  endLoc: (int, int)
+};
+
 let string_of_char = (c: char) : string => {
   Js.String.fromCharCode(Char.code(c))
 };

--- a/src/LazyStream.re
+++ b/src/LazyStream.re
@@ -52,3 +52,15 @@ let toArray = (stream: t('a)) => {
 
   populate()
 };
+
+let withSideeffect = (stream: t('a), sideeffect: [@bs] ('a) => unit) : t('a) => {
+  from([@bs] () => {
+    switch (next(stream)) {
+    | Some(value) as x => {
+      ([@bs] sideeffect(value));
+      x
+    }
+    | None => None
+    }
+  });
+};

--- a/src/LazyStream.re
+++ b/src/LazyStream.re
@@ -54,7 +54,7 @@ let toArray = (stream: t('a)) => {
 };
 
 /* wraps a LazyStream and executes a sideeffect when a new value is being emitted */
-let withSideeffect = (stream: t('a), sideeffect: [@bs] ('a) => unit) : t('a) => {
+let withSideeffect = (sideeffect: [@bs] ('a) => unit, stream: t('a)) : t('a) => {
   from([@bs] () => {
     switch (next(stream)) {
     | Some(value) as x => {

--- a/src/LazyStream.re
+++ b/src/LazyStream.re
@@ -53,6 +53,7 @@ let toArray = (stream: t('a)) => {
   populate()
 };
 
+/* wraps a LazyStream and executes a sideeffect when a new value is being emitted */
 let withSideeffect = (stream: t('a), sideeffect: [@bs] ('a) => unit) : t('a) => {
   from([@bs] () => {
     switch (next(stream)) {

--- a/src/Lexer.re
+++ b/src/Lexer.re
@@ -1,18 +1,12 @@
 open Common;
 
-/* an error raised by the lexer contains a message and a line number */
-exception LexerError(string, int);
+/* an error raised by the lexer contains a message and a row/column location */
+exception LexerError(string, (int, int));
 
 /* For tokens that are opening or closing the difference can be abstracted w/o their value */
 type pairwiseKind =
   | Opening
   | Closing;
-
-/* For tokens that additionally need whitespace significance encoded */
-type combinatedPairwiseKind =
-  | Opening
-  | Closing
-  | OpeningSeparated;
 
 /* For Quote tokens and the string loop to identify the closing quote */
 type quoteKind =
@@ -22,14 +16,13 @@ type quoteKind =
 /* A token's value represented by its type constructor and the value type */
 type tokenValue =
   | Interpolation(interpolation)
-  | Paren(combinatedPairwiseKind)
-  | Bracket(combinatedPairwiseKind)
+  | Paren(pairwiseKind)
+  | Bracket(pairwiseKind)
   | Brace(pairwiseKind)
   | Word(string)
   | AtWord(string)
   | Str(string)
   | Quote(quoteKind)
-  | WordCombinator
   | Exclamation
   | Equal
   | Colon
@@ -44,8 +37,8 @@ type tokenValue =
   | Dollar
   | EOF;
 
-/* A token represented by its value and a line number */
-type token = Token(tokenValue, int);
+/* A token carries a value, a start location, and an end location */
+type token = Token(tokenValue, (int, int), (int, int));
 
 /* Stream type for the LexerStream */
 type lexerStream = LazyStream.t(token);
@@ -59,7 +52,6 @@ type argumentMode =
 /* Modes the lexer can be in, allowing encapsulated and specialised logic */
 type lexerMode =
   | MainLoop
-  | CombinatorLoop
   | StringEndLoop
   | SingleQuoteStringLoop
   | DoubleQuoteStringLoop
@@ -70,20 +62,61 @@ type lexerMode =
 
 /* Running state for tokenisation */
 type state = {
-  /* value to keep track of the current line number; must be updated for every newline */
-  mutable line: int,
+  /* location variable to keep track of (row, line) */
+  mutable loc: (int, int),
+  /* location variable to keep track of the potential end of a token */
+  mutable endLoc: option((int, int)),
+  /* location variable to mark the potential start of a token */
+  mutable startLoc: option((int, int)),
+  /* instructs the sideeffect stream to set the startLoc on the next char */
+  mutable shouldSetStartLoc: bool,
   /* a buffer holding the last emitted tokenValue */
   mutable lastTokenValue: tokenValue,
   /* the current mode of the lexer */
   mutable mode: lexerMode
 };
 
-let lexer = (s: Input.inputStream) => {
+let lexer = (input: Input.inputStream) => {
   let state = {
-    line: 1,
+    loc: (1, 0),
+    startLoc: None,
+    endLoc: None,
+    shouldSetStartLoc: false,
     lastTokenValue: EOF,
     mode: MainLoop
   };
+
+  /* get the current endLoc */
+  let getEndLocation = () => state.loc;
+
+  /* sets the current start/end location at loc */
+  let markStartLocation = () => state.startLoc = Some(state.loc);
+  let markEndLocation = () => state.endLoc = Some(state.loc);
+
+  /* count up the current column on endLoc */
+  let nextColumn = () => {
+    let (row, column) = state.loc;
+    state.loc = (row, column + 1);
+  };
+
+  /* count up the current row on endLoc */
+  let nextRow = () => {
+    let (row, _) = state.loc;
+    state.loc = (row + 1, 0);
+  };
+
+  /* wrap inputStream in row/column counting sideeffect */
+  let s = LazyStream.withSideeffect(input, [@bs] (x: Input.inputValue) => {
+    switch x {
+    | Char('\n') => nextRow()
+    | _ => nextColumn()
+    };
+
+    if (state.shouldSetStartLoc) {
+      markStartLocation();
+      state.shouldSetStartLoc = false;
+    };
+  });
 
   /* checks whether next input value is equal to char */
   let isNextCharEqual = (matching: char) => {
@@ -123,28 +156,18 @@ let lexer = (s: Input.inputStream) => {
       LazyStream.junk(s) /* throw away the trailing slash */
     }
 
-    /* count up current line number inside comments */
-    | Some(Char('\n')) =>
-      state.line = state.line + 1;
-      skipCommentContent()
-
     /* any char is recursively ignored */
     | Some(_) => skipCommentContent()
 
     /* a comment should be closed, since we don't want to deal with input weirdness */
-    | None => raise(LexerError(unexpected_msg("eof", "comment") ++ expected_msg("comment to be closed"), state.line))
+    | None => raise(LexerError(unexpected_msg("eof", "comment") ++ expected_msg("comment to be closed"), getEndLocation()))
     }
   };
+
   /* skip all whitespace-like characters */
   let rec skipWhitespaces = () => {
     switch (LazyStream.peek(s)) {
-    /* count up current line number */
-    | Some(Char('\n')) => {
-      LazyStream.junk(s); /* skip over newline */
-      state.line = state.line + 1;
-      skipWhitespaces()
-    }
-
+    | Some(Char('\n'))
     | Some(Char(' '))
     | Some(Char('\t'))
     | Some(Char('\r')) => {
@@ -185,22 +208,16 @@ let lexer = (s: Input.inputStream) => {
       /* detect start of a hex code as those have a different escape syntax */
       | Some(Char(c)) when isHexDigitChar(c) => captureHexDigits(string_of_char(c))
 
-      /* count up current line number even for escaped newlines */
-      | Some(Char('\n')) => {
-        state.line = state.line + 1;
-        "\n"
-      }
-
       /* capture a single non-hex char as the escaped content (spec-compliancy disallows newlines, but they are supported in practice) */
       | Some(Char(c)) => string_of_char(c)
 
       /* it's too risky to allow value-interpolations as part of escapes */
       | Some(Interpolation(_)) => {
-        raise(LexerError(unexpected_msg("interpolation", "escape sequence"), state.line));
+        raise(LexerError(unexpected_msg("interpolation", "escape sequence"), getEndLocation()));
       }
 
       /* an escape (backslash) must be followed by at least another char, thus an EOF is unacceptable */
-      | None => raise(LexerError(unexpected_msg("eof", "escape sequence"), state.line))
+      | None => raise(LexerError(unexpected_msg("eof", "escape sequence"), getEndLocation()))
       };
 
     "\\" ++ escaped
@@ -208,6 +225,8 @@ let lexer = (s: Input.inputStream) => {
 
   /* captures the content of a word, assuming that the word's start is captured in `str` */
   let rec captureWordContent = (str: string) : string => {
+    markEndLocation(); /* mark potential end location for word token */
+
     switch (LazyStream.peek(s)) {
     /* escaped content is allowed anywhere inside a word */
     | Some(Char('\\')) => {
@@ -236,18 +255,33 @@ let lexer = (s: Input.inputStream) => {
 
   /* adds a double quote to the beginning of an unquoted url() argument */
   let unquotedStringArgStartLoop = () : tokenValue => {
+    /* mark location for double quote token */
+    markStartLocation();
+    markEndLocation();
+
     state.mode = UnquotedStringArgLoop;
+
     Quote(Double)
   };
 
   /* adds a double quote to the end of an unquoted url() argument */
   let unquotedStringArgEndLoop = () : tokenValue => {
+    /* mark location for double quote token */
+    markStartLocation();
+    markEndLocation();
+
     state.mode = MainLoop;
     Quote(Double)
   };
 
   /* tokenise unquoted arguments like the content of url() or calc() */
   let rec unquotedArgumentLoop = (kind: argumentMode, nestedness: int, str: string) : tokenValue => {
+    if (str == "") {
+      markStartLocation(); /* mark start location when str is not set yet */
+    };
+
+    markEndLocation(); /* mark potential end location for word token */
+
     switch (LazyStream.peek(s), kind, nestedness) {
     /* escaped content is allowed anywhere inside an unquoted argument */
     | (Some(Char('\\')), _, _) => {
@@ -279,7 +313,7 @@ let lexer = (s: Input.inputStream) => {
 
     /* nested arguments (parentheses) inside StrictString arguments are not allowed */
     | (Some(Char('(')), StringArg, _) => {
-      raise(LexerError(unexpected_msg("'('", "unquoted argument"), state.line));
+      raise(LexerError(unexpected_msg("'('", "unquoted argument"), getEndLocation()));
     }
 
     | (Some(Char('(')), ContentArg, _) => {
@@ -302,14 +336,8 @@ let lexer = (s: Input.inputStream) => {
 
       | Some(Char(')')) when str === "" => unquotedStringArgEndLoop()
 
-      | _ => raise(LexerError(unexpected_msg("whitespace", "unquoted argument") ++ expected_msg("')'"), state.line))
+      | _ => raise(LexerError(unexpected_msg("whitespace", "unquoted argument") ++ expected_msg("')'"), getEndLocation()))
       }
-    }
-
-    /* in calc() whitespaces can appear anywhere, so we have to count newlines */
-    | (Some(Char('\n')), ContentArg, _) => {
-      state.line = state.line + 1;
-      unquotedArgumentLoop(kind, nestedness, str ++ "\n")
     }
 
     /* in url() quotes must be escaped, since extra quotes will be added */
@@ -330,16 +358,19 @@ let lexer = (s: Input.inputStream) => {
     /* ...but when the string is empty (next loop) we emit the interpolation */
     | (Some(Interpolation(value)), _, _) => {
       LazyStream.junk(s); /* throw away the interpolation */
+      state.shouldSetStartLoc = true; /* capture next-char's location as the start of the next string */
       Interpolation(value)
     }
 
     /* an unquoted argument must be explicitly ended, thus an EOF is unacceptable */
-    | (None, _, _) => raise(LexerError(unexpected_msg("eof", "unquoted argument") ++ expected_msg("')'"), state.line))
+    | (None, _, _) => raise(LexerError(unexpected_msg("eof", "unquoted argument") ++ expected_msg("')'"), getEndLocation()))
     }
   };
 
   /* tokenise a string (excluding quotes which are separate tokens) */
   let rec stringLoop = (kind: quoteKind, str: string) : tokenValue => {
+    markEndLocation(); /* mark potential end location for word token */
+
     switch (LazyStream.peek(s)) {
     /* escaped content is allowed anywhere inside a string */
     | Some(Char('\\')) => {
@@ -359,7 +390,7 @@ let lexer = (s: Input.inputStream) => {
     }
 
     /* newlines inside strings are not permitted, except when they're escaped */
-    | Some(Char('\n')) => raise(LexerError(unexpected_msg("newline", "string"), state.line))
+    | Some(Char('\n')) => raise(LexerError(unexpected_msg("newline", "string"), getEndLocation()))
 
     /* every char is accepted into the string */
     | Some(Char(c)) => {
@@ -373,11 +404,12 @@ let lexer = (s: Input.inputStream) => {
     /* ...but when the string is empty (next loop) we emit the interpolation */
     | Some(Interpolation(value)) => {
       LazyStream.junk(s); /* throw away the interpolation */
+      state.shouldSetStartLoc = true; /* capture next-char's location as the start of the next string */
       Interpolation(value)
     }
 
     /* a string must be explicitly ended, thus an EOF is unacceptable */
-    | None => raise(LexerError(unexpected_msg("eof", "string"), state.line))
+    | None => raise(LexerError(unexpected_msg("eof", "string"), getEndLocation()))
     }
   };
 
@@ -388,7 +420,7 @@ let lexer = (s: Input.inputStream) => {
     switch (LazyStream.next(s)) {
     | Some(Char('"')) => Quote(Double)
     | Some(Char('\'')) => Quote(Single)
-    | _ => raise(LexerError(unexpected_msg("token", "string") ++ expected_msg("end of string"), state.line))
+    | _ => raise(LexerError(unexpected_msg("token", "string") ++ expected_msg("end of string"), getEndLocation()))
     }
   };
 
@@ -397,6 +429,8 @@ let lexer = (s: Input.inputStream) => {
     /* single char tokens */
     | Some(Char('{')) => Brace(Opening)
     | Some(Char('}')) => Brace(Closing)
+    | Some(Char('[')) => Bracket(Opening)
+    | Some(Char(']')) => Bracket(Closing)
     | Some(Char('!')) => Exclamation
     | Some(Char('=')) => Equal
     | Some(Char(':')) => Colon
@@ -407,28 +441,22 @@ let lexer = (s: Input.inputStream) => {
     | Some(Char(',')) => Comma
     | Some(Char('|')) => Pipe
     | Some(Char('$')) => Dollar
-
-    /* single char token; closing bracket, see below for opening */
-    | Some(Char(']')) => Bracket(Closing)
-
-    /* emit (non-/)separated bracket */
-    | Some(Char('[')) => {
-      switch (state.lastTokenValue) {
-      | Word(_)
-      | Interpolation(_) => Bracket(Opening)
-      | _ => Bracket(OpeningSeparated)
-      }
-    }
+    | Some(Char('*')) => Asterisk
+    | Some(Char('&')) => Ampersand
 
     /* single char token; closing parenthesis, see below for opening */
     | Some(Char(')')) => Paren(Closing)
 
     /* detect whether parenthesis is part of url() or calc(), and emit (non-/)separated parenthesis */
     | Some(Char('(')) => {
-      skipWhitespaces(); /* skip all leading whitespaces */
-
       switch state.lastTokenValue {
       | Word("url") => {
+        /* mark location for opening paren token */
+        markStartLocation();
+        markEndLocation();
+
+        skipWhitespaces(); /* skip all leading whitespaces */
+
         state.mode = UnquotedStringArgStartLoop;
         Paren(Opening)
       }
@@ -437,61 +465,42 @@ let lexer = (s: Input.inputStream) => {
         Paren(Opening)
       }
 
-      | Word(_)
-      | Interpolation(_) => Paren(Opening)
-
-      | _ => Paren(OpeningSeparated)
+      | _ => Paren(Opening)
       }
     }
 
-    /* skip over carriage returns, tabs, and whitespaces */
+    /* skip over carriage returns, tabs, newlines, and whitespaces */
     | Some(Char('\r'))
     | Some(Char('\t'))
+    | Some(Char('\n'))
     | Some(Char(' ')) => mainLoop()
-
-    /* count up current line number and search next tokenValue */
-    | Some(Char('\n')) => {
-      state.line = state.line + 1;
-      mainLoop()
-    }
 
     /* detect double quotes and queue StringLoop */
     | Some(Char('"')) => {
       state.mode = DoubleQuoteStringLoop;
+      state.shouldSetStartLoc = true; /* capture next-char's location as the start of the string */
       Quote(Double)
     }
 
     /* detect single quotes and queue StringLoop */
     | Some(Char('\'')) => {
       state.mode = SingleQuoteStringLoop;
+      state.shouldSetStartLoc = true; /* capture next-char's location as the start of the string */
       Quote(Single)
     }
 
     /* detect at-words and parse it like a normal word afterwards */
     | Some(Char('@')) => {
+      markStartLocation(); /* mark start of AtWord */
+
       /* at-words will never be composed with interpolations, so no switch to WordLoop */
       let wordContent = captureWordContent("@");
       AtWord(wordContent)
     }
 
-    /* detect asterisk token and enter combinator loop */
-    | Some(Char('*')) => {
-      /* switch to combinator to emit a WordCombinator when no space occurs between interpolations/words */
-      state.mode = CombinatorLoop;
-      Asterisk
-    }
-
-    /* detect ampersand token and enter combinator loop */
-    | Some(Char('&')) => {
-      /* switch to combinator to emit a WordCombinator when no space occurs between interpolations/words */
-      state.mode = CombinatorLoop;
-      Ampersand
-    }
-
     /* detect start of a word and parse it */
     | Some(Char(c)) when isWordStartChar(c) => {
-      /* switch to combinator to emit a WordCombinator when no space occurs between interpolations/words */
-      state.mode = CombinatorLoop;
+      markStartLocation(); /* mark start of Word */
 
       /* capture rest of word */
       let wordContent = captureWordContent(string_of_char(c));
@@ -500,8 +509,7 @@ let lexer = (s: Input.inputStream) => {
 
     /* detect backslash i.e. escape as start of a word and parse it */
     | Some(Char('\\')) => {
-      /* switch to combinator to emit a WordCombinator when no space occurs between interpolations/words */
-      state.mode = CombinatorLoop;
+      markStartLocation(); /* mark start of Word */
 
       /* capture escaped content and rest of word */
       let wordContent = captureWordContent(captureEscapedContent());
@@ -509,12 +517,7 @@ let lexer = (s: Input.inputStream) => {
     }
 
     /* pass-through interpolation */
-    | Some(Interpolation(x)) => {
-      /* switch to combinator to emit a WordCombinator when no space occurs between interpolations/words */
-      state.mode = CombinatorLoop;
-
-      Interpolation(x)
-    }
+    | Some(Interpolation(x)) => Interpolation(x)
 
     /* detect and skip comments, then search next tokenValue */
     | Some(Char('/')) when isNextCharEqual('*') => {
@@ -526,28 +529,10 @@ let lexer = (s: Input.inputStream) => {
 
     /* all unrecognised characters will be raised outside of designated matching loops */
     | Some(Char(c)) => {
-      raise(LexerError(unexpected_msg("'" ++ string_of_char(c) ++ "'", "tokens"), state.line));
+      raise(LexerError(unexpected_msg("'" ++ string_of_char(c) ++ "'", "tokens"), getEndLocation()));
     }
 
     | None => EOF
-    }
-  };
-
-  /* emits a combination token when the last and next token are an interpolation/word */
-  let combinatorLoop = () : tokenValue => {
-    state.mode = MainLoop;
-
-    switch (LazyStream.peek(s)) {
-    /* emit WordCombinator when next token will be an interpolation or ampersand */
-    | Some(Interpolation(_))
-    | Some(Char('&')) => WordCombinator
-    | Some(Char('*')) => WordCombinator
-
-    /* emit WordCombinator when next token will be a word */
-    | Some(Char(c)) when isWordStartChar(c) => WordCombinator
-
-    /* pass over to MainLoop immediately if no word or interpolation followed */
-    | _ => mainLoop()
     }
   };
 
@@ -556,7 +541,6 @@ let lexer = (s: Input.inputStream) => {
     let token =
       switch state.mode {
       | MainLoop => mainLoop()
-      | CombinatorLoop => combinatorLoop()
       | SingleQuoteStringLoop => stringLoop(Single, "")
       | DoubleQuoteStringLoop => stringLoop(Double, "")
       | StringEndLoop => stringEndLoop()
@@ -571,7 +555,25 @@ let lexer = (s: Input.inputStream) => {
     | value => {
       /* store token as "last token" for unquote argument detection */
       state.lastTokenValue = value;
-      Some(Token(value, state.line))
+
+      /* fallback to endLoc and then loc */
+      let startLoc = switch (state.startLoc, state.endLoc) {
+        | (None, None) => state.loc
+        | (None, Some(loc)) => loc
+        | (Some(loc), _) => loc
+      };
+
+      /* fallback to loc */
+      let endLoc = switch (state.endLoc) {
+        | None => state.loc
+        | Some(loc) => loc
+      };
+
+      /* reset start/end location markers */
+      state.startLoc = None;
+      state.endLoc = None;
+
+      Some(Token(value, startLoc, endLoc))
     }
     }
   });

--- a/src/Lexer.re
+++ b/src/Lexer.re
@@ -106,7 +106,7 @@ let lexer = (input: Input.inputStream) => {
   };
 
   /* wrap inputStream in row/column counting sideeffect */
-  let s = LazyStream.withSideeffect(input, [@bs] (x: Input.inputValue) => {
+  let s = input |> LazyStream.withSideeffect([@bs] (x: Input.inputValue) => {
     switch x {
     | Char('\n') => nextRow()
     | _ => nextColumn()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz#2349d7ec04b3a06945ae173280ef8579b63728e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@types/node@*":
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -16,9 +28,19 @@ acorn-globals@^3.1.0:
   dependencies:
     acorn "^4.0.4"
 
+acorn-globals@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
+  dependencies:
+    acorn "^5.0.0"
+
 acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+
+acorn@^5.0.0, acorn@^5.1.2:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
 acorn@^5.1.1:
   version "5.1.2"
@@ -351,6 +373,13 @@ babel-jest@^21.2.0:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
 
+babel-jest@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.0.4.tgz#533c46de37d7c9d7612f408c76314be9277e0c26"
+  dependencies:
+    babel-plugin-istanbul "^4.1.5"
+    babel-preset-jest "^22.0.3"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -367,7 +396,7 @@ babel-plugin-closure-elimination@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-closure-elimination/-/babel-plugin-closure-elimination-1.3.0.tgz#3217fbf6d416dfdf14ff41a8a34e4d0a6bfc22b2"
 
-babel-plugin-istanbul@^4.0.0:
+babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
@@ -378,6 +407,10 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
+
+babel-plugin-jest-hoist@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.3.tgz#62cde5fe962fd41ae89c119f481ca5cd7dd48bb4"
 
 babel-plugin-minify-dead-code-elimination@^0.2.0:
   version "0.2.0"
@@ -653,6 +686,13 @@ babel-preset-jest@^21.2.0:
     babel-plugin-jest-hoist "^21.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
+babel-preset-jest@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.0.3.tgz#e2bb6f6b4a509d3ea0931f013db78c5a84856693"
+  dependencies:
+    babel-plugin-jest-hoist "^22.0.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
@@ -723,6 +763,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+bindings@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -774,6 +818,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-process-hrtime@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+
 browser-resolve@^1.11.0, browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
@@ -787,11 +835,11 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000760"
     electron-to-chromium "^1.3.27"
 
-bs-jest@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/bs-jest/-/bs-jest-0.2.0.tgz#62576e00c35f069d7681b9bb9bfd744dc7197eb7"
+bs-jest@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/bs-jest/-/bs-jest-0.3.2.tgz#b13cef06a965988a404fd74cac351f3b5bce53b1"
   dependencies:
-    jest "^21.2.1"
+    jest "^22.0.4"
 
 bs-loader@^2.0.0:
   version "2.0.0"
@@ -856,17 +904,17 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+chalk@^2.0.0, chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+chalk@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -996,6 +1044,12 @@ debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1041,9 +1095,17 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.0.tgz#81fe5df81b3f057052cde3a9fa9bf536a85b9ab0"
 
 duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
@@ -1085,6 +1147,16 @@ es-abstract@^1.4.3:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.5.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -1097,7 +1169,7 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.6.1:
+escodegen@^1.6.1, escodegen@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
   dependencies:
@@ -1188,6 +1260,17 @@ expect@^21.2.1:
     jest-matcher-utils "^21.2.1"
     jest-message-util "^21.2.1"
     jest-regex-util "^21.2.0"
+
+expect@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-22.0.3.tgz#bb486de7d41bf3eb60d3b16dfd1c158a4d91ddfa"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^22.0.3"
+    jest-get-type "^22.0.3"
+    jest-matcher-utils "^22.0.3"
+    jest-message-util "^22.0.3"
+    jest-regex-util "^22.0.3"
 
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
@@ -1705,6 +1788,22 @@ istanbul-api@^1.1.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
+istanbul-api@^1.1.14:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
+  dependencies:
+    async "^2.1.4"
+    fileset "^2.0.2"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.9.1"
+    istanbul-lib-report "^1.1.2"
+    istanbul-lib-source-maps "^1.2.2"
+    istanbul-reports "^1.1.3"
+    js-yaml "^3.7.0"
+    mkdirp "^0.5.1"
+    once "^1.4.0"
+
 istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
@@ -1715,9 +1814,27 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+  dependencies:
+    append-transform "^0.4.0"
+
 istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz#66f6c9421cc9ec4704f76f2db084ba9078a2b532"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-instrument@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
@@ -1736,11 +1853,30 @@ istanbul-lib-report@^1.1.1:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
+istanbul-lib-report@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
+  dependencies:
+    istanbul-lib-coverage "^1.1.1"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
 istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
   dependencies:
     debug "^2.6.3"
+    istanbul-lib-coverage "^1.1.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-lib-source-maps@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
+  dependencies:
+    debug "^3.1.0"
     istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
@@ -1752,9 +1888,21 @@ istanbul-reports@^1.1.2:
   dependencies:
     handlebars "^4.0.3"
 
+istanbul-reports@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
+  dependencies:
+    handlebars "^4.0.3"
+
 jest-changed-files@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
+  dependencies:
+    throat "^4.0.0"
+
+jest-changed-files@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.0.3.tgz#3771315acfa24a0ed7e6c545de620db6f1b2d164"
   dependencies:
     throat "^4.0.0"
 
@@ -1792,6 +1940,42 @@ jest-cli@^21.2.1:
     worker-farm "^1.3.1"
     yargs "^9.0.0"
 
+jest-cli@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.0.4.tgz#0052abaad45c57861c05da8ab5d27bad13ad224d"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    istanbul-api "^1.1.14"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-instrument "^1.8.0"
+    istanbul-lib-source-maps "^1.2.1"
+    jest-changed-files "^22.0.3"
+    jest-config "^22.0.4"
+    jest-environment-jsdom "^22.0.4"
+    jest-get-type "^22.0.3"
+    jest-haste-map "^22.0.3"
+    jest-message-util "^22.0.3"
+    jest-regex-util "^22.0.3"
+    jest-resolve-dependencies "^22.0.3"
+    jest-runner "^22.0.4"
+    jest-runtime "^22.0.4"
+    jest-snapshot "^22.0.3"
+    jest-util "^22.0.4"
+    jest-worker "^22.0.3"
+    micromatch "^2.3.11"
+    node-notifier "^5.1.2"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^10.0.3"
+
 jest-config@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
@@ -1808,6 +1992,22 @@ jest-config@^21.2.1:
     jest-validate "^21.2.1"
     pretty-format "^21.2.1"
 
+jest-config@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.0.4.tgz#9c2a46c0907b1a1af54d9cdbf18e99b447034e11"
+  dependencies:
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^22.0.4"
+    jest-environment-node "^22.0.4"
+    jest-get-type "^22.0.3"
+    jest-jasmine2 "^22.0.4"
+    jest-regex-util "^22.0.3"
+    jest-resolve "^22.0.4"
+    jest-util "^22.0.4"
+    jest-validate "^22.0.3"
+    pretty-format "^22.0.3"
+
 jest-diff@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
@@ -1817,9 +2017,24 @@ jest-diff@^21.2.1:
     jest-get-type "^21.2.0"
     pretty-format "^21.2.1"
 
+jest-diff@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.0.3.tgz#ffed5aba6beaf63bb77819ba44dd520168986321"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.0.3"
+    pretty-format "^22.0.3"
+
 jest-docblock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+
+jest-docblock@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.0.3.tgz#c33aa22682b9fc68a5373f5f82994428a2ded601"
+  dependencies:
+    detect-newline "^2.1.0"
 
 jest-environment-jsdom@^21.2.1:
   version "21.2.1"
@@ -1829,6 +2044,14 @@ jest-environment-jsdom@^21.2.1:
     jest-util "^21.2.1"
     jsdom "^9.12.0"
 
+jest-environment-jsdom@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.0.4.tgz#5723d4e724775ed38948de792e62f2d6a7f452df"
+  dependencies:
+    jest-mock "^22.0.3"
+    jest-util "^22.0.4"
+    jsdom "^11.5.1"
+
 jest-environment-node@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
@@ -1836,9 +2059,20 @@ jest-environment-node@^21.2.1:
     jest-mock "^21.2.0"
     jest-util "^21.2.1"
 
+jest-environment-node@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.0.4.tgz#068671f85a545f96a5469be3a3dd228fca79c709"
+  dependencies:
+    jest-mock "^22.0.3"
+    jest-util "^22.0.4"
+
 jest-get-type@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-get-type@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.0.3.tgz#fa894b677c0fcd55eff3fd8ee28c7be942e32d36"
 
 jest-haste-map@^21.2.0:
   version "21.2.0"
@@ -1850,6 +2084,17 @@ jest-haste-map@^21.2.0:
     micromatch "^2.3.11"
     sane "^2.0.0"
     worker-farm "^1.3.1"
+
+jest-haste-map@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.0.3.tgz#c9ecb5c871c5465d4bde4139e527fa0dc784aa2d"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^22.0.3"
+    jest-worker "^22.0.3"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
 
 jest-jasmine2@^21.2.1:
   version "21.2.1"
@@ -1864,6 +2109,28 @@ jest-jasmine2@^21.2.1:
     jest-snapshot "^21.2.1"
     p-cancelable "^0.3.0"
 
+jest-jasmine2@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.0.4.tgz#f7c0965116efe831ec674dc954b0134639b3dcee"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    expect "^22.0.3"
+    graceful-fs "^4.1.11"
+    jest-diff "^22.0.3"
+    jest-matcher-utils "^22.0.3"
+    jest-message-util "^22.0.3"
+    jest-snapshot "^22.0.3"
+    source-map-support "^0.5.0"
+
+jest-leak-detector@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.0.3.tgz#b64904f0e8954a11edb79b0809ff4717fa762d99"
+  dependencies:
+    pretty-format "^22.0.3"
+  optionalDependencies:
+    weak "^1.0.1"
+
 jest-matcher-utils@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
@@ -1871,6 +2138,14 @@ jest-matcher-utils@^21.2.1:
     chalk "^2.0.1"
     jest-get-type "^21.2.0"
     pretty-format "^21.2.1"
+
+jest-matcher-utils@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.0.3.tgz#2ec15ca1af7dcabf4daddc894ccce224b948674e"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.0.3"
+    pretty-format "^22.0.3"
 
 jest-message-util@^21.2.1:
   version "21.2.1"
@@ -1880,19 +2155,43 @@ jest-message-util@^21.2.1:
     micromatch "^2.3.11"
     slash "^1.0.0"
 
+jest-message-util@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.0.3.tgz#bf674b2762ef2dd53facf2136423fcca264976df"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
 
+jest-mock@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.0.3.tgz#c875e47b5b729c6c020a2fab317b275c0cf88961"
+
 jest-regex-util@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
+
+jest-regex-util@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.0.3.tgz#c5c10229de5ce2b27bf4347916d95b802ae9aa4d"
 
 jest-resolve-dependencies@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
   dependencies:
     jest-regex-util "^21.2.0"
+
+jest-resolve-dependencies@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.0.3.tgz#202ddf370069702cd1865a1952fcc7e52c92720e"
+  dependencies:
+    jest-regex-util "^22.0.3"
 
 jest-resolve@^21.2.0:
   version "21.2.0"
@@ -1901,6 +2200,13 @@ jest-resolve@^21.2.0:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     is-builtin-module "^1.0.0"
+
+jest-resolve@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.0.4.tgz#a6e47f55e9388c7341b5e9732aedc6fe30906121"
+  dependencies:
+    browser-resolve "^1.11.2"
+    chalk "^2.0.1"
 
 jest-runner@^21.2.1:
   version "21.2.1"
@@ -1916,6 +2222,21 @@ jest-runner@^21.2.1:
     pify "^3.0.0"
     throat "^4.0.0"
     worker-farm "^1.3.1"
+
+jest-runner@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.0.4.tgz#3aa43a31b05ce8271539df580c2eb916023d3367"
+  dependencies:
+    jest-config "^22.0.4"
+    jest-docblock "^22.0.3"
+    jest-haste-map "^22.0.3"
+    jest-jasmine2 "^22.0.4"
+    jest-leak-detector "^22.0.3"
+    jest-message-util "^22.0.3"
+    jest-runtime "^22.0.4"
+    jest-util "^22.0.4"
+    jest-worker "^22.0.3"
+    throat "^4.0.0"
 
 jest-runtime@^21.2.1:
   version "21.2.1"
@@ -1939,6 +2260,29 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
+jest-runtime@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.0.4.tgz#8f69aa7b5fbb3acd35dc262cbf654e563f69b7b4"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^22.0.4"
+    babel-plugin-istanbul "^4.1.5"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    graceful-fs "^4.1.11"
+    jest-config "^22.0.4"
+    jest-haste-map "^22.0.3"
+    jest-regex-util "^22.0.3"
+    jest-resolve "^22.0.4"
+    jest-util "^22.0.4"
+    json-stable-stringify "^1.0.1"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^10.0.3"
+
 jest-snapshot@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
@@ -1949,6 +2293,17 @@ jest-snapshot@^21.2.1:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     pretty-format "^21.2.1"
+
+jest-snapshot@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.0.3.tgz#a949b393781d2fdb4773f6ea765dd67ad1da291e"
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^22.0.3"
+    jest-matcher-utils "^22.0.3"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^22.0.3"
 
 jest-util@^21.2.1:
   version "21.2.1"
@@ -1962,6 +2317,18 @@ jest-util@^21.2.1:
     jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
+jest-util@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.0.4.tgz#d920a513e0645aaab030cee38e4fe7d5bed8bb6d"
+  dependencies:
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^22.0.3"
+    jest-validate "^22.0.3"
+    mkdirp "^0.5.1"
+
 jest-validate@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
@@ -1971,11 +2338,32 @@ jest-validate@^21.2.1:
     leven "^2.1.0"
     pretty-format "^21.2.1"
 
+jest-validate@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.0.3.tgz#2850d949a36c48b1a40f7eebae1d8539126f7829"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.0.3"
+    leven "^2.1.0"
+    pretty-format "^22.0.3"
+
+jest-worker@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.0.3.tgz#30433faca67814a8f80559f75ab2ceaa61332fd2"
+  dependencies:
+    merge-stream "^1.0.1"
+
 jest@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
   dependencies:
     jest-cli "^21.2.1"
+
+jest@^22.0.4:
+  version "22.0.4"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-22.0.4.tgz#d3cf560ece6b825b115dce80b9826ceb40f87961"
+  dependencies:
+    jest-cli "^22.0.4"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -1991,6 +2379,35 @@ js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdom@^11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"
+  dependencies:
+    abab "^1.0.3"
+    acorn "^5.1.2"
+    acorn-globals "^4.0.0"
+    array-equal "^1.0.0"
+    browser-process-hrtime "^0.1.2"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    domexception "^1.0.0"
+    escodegen "^1.9.0"
+    html-encoding-sniffer "^1.0.1"
+    left-pad "^1.2.0"
+    nwmatcher "^1.4.3"
+    parse5 "^3.0.2"
+    pn "^1.0.0"
+    request "^2.83.0"
+    request-promise-native "^1.0.3"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.3"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^6.3.0"
+    xml-name-validator "^2.0.1"
 
 jsdom@^9.12.0:
   version "9.12.0"
@@ -2085,6 +2502,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+left-pad@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
+
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -2143,7 +2564,11 @@ lodash.some@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
-lodash@^4.14.0, lodash@^4.17.4:
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2189,6 +2614,12 @@ mem@^1.1.0:
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -2254,6 +2685,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+nan@^2.0.5:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
@@ -2266,7 +2701,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.0.2:
+node-notifier@^5.0.2, node-notifier@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
   dependencies:
@@ -2345,7 +2780,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.9 < 2.0.0":
+"nwmatcher@>= 1.3.9 < 2.0.0", nwmatcher@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
@@ -2360,6 +2795,13 @@ object-assign@^4.1.0:
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.getownpropertydescriptors@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2459,6 +2901,12 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+parse5@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -2539,6 +2987,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2550,6 +3002,13 @@ preserve@^0.2.0:
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
+pretty-format@^22.0.3:
+  version "22.0.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.0.3.tgz#a2bfa59fc33ad24aa4429981bb52524b41ba5dd7"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -2579,6 +3038,10 @@ pseudomap@^1.0.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 qs@~6.4.0:
   version "6.4.0"
@@ -2648,7 +3111,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.6, readable-stream@^2.1.4:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -2659,6 +3122,12 @@ readable-stream@^2.0.6, readable-stream@^2.1.4:
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+realpath-native@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
+  dependencies:
+    util.promisify "^1.0.0"
 
 refmt@^1.13.7-1:
   version "1.13.7"
@@ -2722,6 +3191,20 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -2749,7 +3232,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0:
+request@^2.79.0, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -2804,7 +3287,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -2964,6 +3447,12 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
+  dependencies:
+    source-map "^0.6.0"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -2973,6 +3462,10 @@ source-map@^0.4.4:
 source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -3011,6 +3504,14 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-combiner@~0.0.4:
   version "0.0.4"
@@ -3161,11 +3662,17 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+tr46@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3221,6 +3728,13 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
@@ -3257,11 +3771,18 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
+weak@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/weak/-/weak-1.0.1.tgz#ab99aab30706959aa0200cb8cf545bb9cb33b99e"
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.0.5"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -3277,6 +3798,14 @@ whatwg-url@^4.3.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^6.3.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.0"
+    webidl-conversions "^4.0.1"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -3363,6 +3892,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.0.3.tgz#6542debd9080ad517ec5048fb454efe9e4d4aaae"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
- Remove `WordCombinator`
- Add start and end location to Lexer's token
- Track token ranges in Parser (`getTokenValue`)
- Make Parser rely on last and next range instead of `WordCombinator`