### PR TITLE
Add support for partial interpolations

### DIFF
--- a/__tests__/Parser_test.re
+++ b/__tests__/Parser_test.re
@@ -830,6 +830,24 @@ describe("Parser", () => {
       |];
     });
 
+    /* Parse: `${partial};color: blue;` */
+    it("parses a partial followed by a semicolon and before a declaration on the same line", () => {
+      let inter = create_interpolation(1);
+
+      expect(parse([|
+        Token(Interpolation(inter), (1, 1), (1, 1)),
+        Token(Semicolon, (1, 2), (1, 2)),
+        Token(Word("color"), (1, 3), (1, 7)),
+        Token(Colon, (1, 8), (1, 8)),
+        Token(Word("blue"), (1, 10), (1, 13)),
+        Token(Semicolon, (1, 14), (1, 14))
+      |])) == [|
+        PartialRef(inter),
+        Property("color"),
+        Value("blue")
+      |];
+    });
+
     it("throws when interpolation on the same line as a declaration are encountered", () => {
       let inter = create_interpolation(1);
 

--- a/__tests__/Parser_test.re
+++ b/__tests__/Parser_test.re
@@ -751,4 +751,100 @@ describe("Parser", () => {
       |])) |> toThrowMessage("unexpected token while parsing values");
     });
   });
+
+  describe("Partial interpolations", () => {
+    open Expect;
+    open! Expect.Operators;
+
+    /* Parse: `${partial}\ncolor: papayawhip;` */
+    it("parses a partial preceding a declaration", () => {
+      let inter = create_interpolation(1);
+
+      expect(parse([|
+        Token(Interpolation(inter), (1, 1), (1, 1)),
+        Token(Word("color"), (2, 1), (2, 5)),
+        Token(Colon, (2, 6), (2, 6)),
+        Token(Word("papayawhip"), (2, 8), (2, 18)),
+        Token(Semicolon, (2, 19), (2, 19))
+      |])) == [|
+        PartialRef(inter),
+        Property("color"),
+        Value("papayawhip"),
+      |];
+    });
+
+    /* Parse: `${partial}\n.test {}` */
+    it("parses a partial preceding a selector", () => {
+      let inter = create_interpolation(1);
+
+      expect(parse([|
+        Token(Interpolation(inter), (1, 1), (1, 1)),
+        Token(Word(".test"), (2, 1), (2, 5)),
+        Token(Brace(Opening), (2, 7), (2, 7)),
+        Token(Brace(Closing), (2, 8), (2, 8))
+      |])) == [|
+        PartialRef(inter),
+        RuleStart(StyleRule),
+        Selector(".test"),
+        RuleEnd
+      |];
+    });
+
+    /* Parse: `${partial}\n.test {}` */
+    it("parses a lone partial inside a rule block", () => {
+      let inter = create_interpolation(1);
+
+      expect(parse([|
+        Token(Word(".test"), (1, 1), (1, 5)),
+        Token(Brace(Opening), (1, 7), (1, 7)),
+        Token(Interpolation(inter), (1, 8), (1, 8)),
+        Token(Brace(Closing), (1, 9), (1, 9))
+      |])) == [|
+        RuleStart(StyleRule),
+        Selector(".test"),
+        PartialRef(inter),
+        RuleEnd
+      |];
+    });
+
+    /* Parse: `color: blue;${partial}\ncolor: blue;` */
+    it("parses a partial inbetween declarations", () => {
+      let inter = create_interpolation(1);
+
+      expect(parse([|
+        Token(Word("color"), (1, 1), (1, 5)),
+        Token(Colon, (1, 6), (1, 6)),
+        Token(Word("blue"), (1, 8), (1, 11)),
+        Token(Semicolon, (1, 12), (1, 12)),
+        Token(Interpolation(inter), (1, 13), (1, 13)),
+        Token(Word("color"), (2, 1), (2, 5)),
+        Token(Colon, (2, 6), (2, 6)),
+        Token(Word("blue"), (2, 8), (2, 11)),
+        Token(Semicolon, (2, 12), (2, 12))
+      |])) == [|
+        Property("color"),
+        Value("blue"),
+        PartialRef(inter),
+        Property("color"),
+        Value("blue")
+      |];
+    });
+
+    it("throws when interpolation on the same line as a declaration are encountered", () => {
+      let inter = create_interpolation(1);
+
+      expect(() => parse([|
+        Token(Interpolation(inter), (1, 1), (1, 1)),
+        Token(Word("color"), (1, 2), (1, 6)),
+        Token(Colon, (1, 7), (1, 7)),
+        Token(Word("green"), (1, 9), (1, 13)),
+        Token(Semicolon, (1, 14), (1, 14))
+      |]))
+        |> toThrowMessage(
+          /* NOTE: Message says *selectors* since parsing declarations is bailed when it doesn't match
+             the appropriate starting pattern (word|interpolation THEN colon) */
+          "Unexpected token while parsing selectors"
+        );
+    });
+  });
 });

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -53,4 +53,4 @@ into ISTF:
   - [x] Selector interpolations
   - [x] Value String interpolations
   - [x] Attribute Selector interpolations
-  - [ ] Partial interpolation
+  - [x] Partial interpolation (heuristic)

--- a/src/Parser.re
+++ b/src/Parser.re
@@ -705,17 +705,18 @@ let parser = (s: Lexer.lexerStream) => {
       parseDeclOrSelector()
     }
 
-    /* partial interpolation heuristic; (1)
-       parse a partial when interpolation is encountered before a selector and after the last mainLoop,
-       where the next token is on a separate line */
-    | (Some(Interpolation(x)), Some(_)) when isSeparatedByRows(firstTokenEndLoc, secondTokenStartLoc) => {
+    /* parse partial interpolation; (1)
+       parse a partial when interpolation is encountered before a closing brace or a semicolon
+       and after the last mainLoop */
+    | (Some(Interpolation(x)), Some(Brace(Closing)))
+    | (Some(Interpolation(x)), Some(Semicolon)) => {
       PartialRef(x)
     }
 
-    /* parse partial interpolation; (2)
-       parse a partial when interpolation is encountered before a closing brace and after the last
-       mainLoop */
-    | (Some(Interpolation(x)), Some(Brace(Closing))) => {
+    /* partial interpolation heuristic; (2)
+       parse a partial when interpolation is encountered before a selector and after the last mainLoop,
+       where the next token is on a separate line */
+    | (Some(Interpolation(x)), Some(_)) when isSeparatedByRows(firstTokenEndLoc, secondTokenStartLoc) => {
       PartialRef(x)
     }
 

--- a/src/Parser.re
+++ b/src/Parser.re
@@ -91,6 +91,12 @@ let isSeparatedBySpaces = (endLoc: (int, int), startLoc: (int, int)) => {
   aRow !== bRow || aColumn + 1 < bColumn
 };
 
+let isSeparatedByRows = (endLoc: (int, int), startLoc: (int, int)) => {
+  let (aRow, _) = endLoc;
+  let (bRow, _) = startLoc;
+  aRow !== bRow
+};
+
 /* Running state for parsing */
 type state = {
   /* value to keep track of the last token's start and end location */
@@ -674,10 +680,17 @@ let parser = (s: Lexer.lexerStream) => {
   };
 
   let rec mainLoop = () : node => {
+    /* consume next token, parse its value, and save its end location */
     let firstToken = LazyStream.next(s);
-    let secondToken = LazyStream.peek(s);
+    let firstTokenValue = getTokenValue(firstToken);
+    let firstTokenEndLoc = state.tokenRange.endLoc;
 
-    switch (getTokenValue(firstToken), getTokenValue(secondToken)) {
+    /* peek at next token, parse its value, and save its start location */
+    let secondToken = LazyStream.peek(s);
+    let secondTokenValue = getTokenValue(secondToken);
+    let secondTokenStartLoc = state.tokenRange.startLoc;
+
+    switch (firstTokenValue, secondTokenValue) {
     /* skip over free semicolons */
     | (Some(Semicolon), _) => mainLoop()
 
@@ -690,6 +703,20 @@ let parser = (s: Lexer.lexerStream) => {
       BufferStream.bufferOption(secondToken, buffer);
 
       parseDeclOrSelector()
+    }
+
+    /* partial interpolation heuristic; (1)
+       parse a partial when interpolation is encountered before a selector and after the last mainLoop,
+       where the next token is on a separate line */
+    | (Some(Interpolation(x)), Some(_)) when isSeparatedByRows(firstTokenEndLoc, secondTokenStartLoc) => {
+      PartialRef(x)
+    }
+
+    /* parse partial interpolation; (2)
+       parse a partial when interpolation is encountered before a closing brace and after the last
+       mainLoop */
+    | (Some(Interpolation(x)), Some(Brace(Closing))) => {
+      PartialRef(x)
     }
 
     /* parse at-rules */


### PR DESCRIPTION
Partial interpolations i.e. mixins;

A heuristic is needed since the interpolations would otherwise
often be mistaken for the start of a selector including a selector
interpolation.

Instead the `mainLoop` (outside of selector/declaration parsing/buffering)
is now looking at tokens after interpolations. If the next token is on a
separate row (read: line) and is not a colon, then the interpolation
is regarded to be a partial.

The same goes for interpolations that are followed by a closing brace.

### Examples

```js
css`
// 1
.test {
  color: red;
  ${partial}
  color: green;
}

// 2
.test {${partial}}

// 3
${partial}
.test {}

// 4, second commit
${partial}; color: green;
`
```

The fourth case could be useful for minification in the source. It's still unambiguous as a semicolon won't be contained in a selector.
  
### Future

The `interpolation+`, `word | interpolation`, `colon` pattern could be observed to remove the heuristic and make partials completely deterministic. This would avoid detecting them as part of the start of selectors when the selector is spread out across multiple lines