### PR TITLE
Refactor ISTF node types for improved safety

### DIFF
--- a/__tests__/Parser_test.re
+++ b/__tests__/Parser_test.re
@@ -1,4 +1,5 @@
 open Jest;
+open IstfNode;
 open Parser;
 
 let it = test;
@@ -34,9 +35,9 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 7), (1, 7)),
         Token(Brace(Closing), (1, 8), (1, 8))
       |])) == [|
-        RuleStart(StyleRule),
-        Selector(".test"),
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".test"),
+        Node(RuleEnd)
       |];
     });
 
@@ -50,12 +51,12 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 9), (1, 9)),
         Token(Brace(Closing), (1, 10), (1, 10))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".first"),
-        SelectorRef(inter),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".first"),
+        RefNode(SelectorRef, inter),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -70,14 +71,14 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 17), (1, 17)),
         Token(Brace(Closing), (1, 18), (1, 18))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".first"),
-        SpaceCombinator,
-        Selector(".second"),
-        SelectorRef(inter),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".first"),
+        Node(SpaceCombinator),
+        StringNode(Selector, ".second"),
+        RefNode(SelectorRef, inter),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -91,12 +92,12 @@ describe("Parser", () => {
         Token(Brace(Closing), (1, 18), (1, 18)),
         Token(Brace(Closing), (1, 19), (1, 19))
       |])) == [|
-        RuleStart(StyleRule),
-        Selector(".first"),
-        RuleStart(StyleRule),
-        Selector(".second"),
-        RuleEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".first"),
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".second"),
+        Node(RuleEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -109,12 +110,12 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 12), (1, 12)),
         Token(Brace(Closing), (1, 13), (1, 13))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        Selector(":hover"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        StringNode(Selector, ":hover"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -128,12 +129,12 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 14), (1, 14)),
         Token(Brace(Closing), (1, 15), (1, 15))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        Selector(":before"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        StringNode(Selector, ":before"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -146,13 +147,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 13), (1, 13)),
         Token(Brace(Closing), (1, 14), (1, 14))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        SpaceCombinator,
-        Selector(":hover"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        Node(SpaceCombinator),
+        StringNode(Selector, ":hover"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -167,16 +168,16 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 15), (1, 15)),
         Token(Brace(Closing), (1, 15), (1, 15))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        ParentSelector,
-        SpaceCombinator,
-        Selector(".abc"),
-        SpaceCombinator,
-        UniversalSelector,
-        Selector(":hover"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        Node(ParentSelector),
+        Node(SpaceCombinator),
+        StringNode(Selector, ".abc"),
+        Node(SpaceCombinator),
+        Node(UniversalSelector),
+        StringNode(Selector, ":hover"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -192,15 +193,15 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 13), (1, 13)),
         Token(Brace(Closing), (1, 14), (1, 14))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        Selector(":"),
-        SelectorRef(inter),
-        SpaceCombinator,
-        Selector("div"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        StringNode(Selector, ":"),
+        RefNode(SelectorRef, inter),
+        Node(SpaceCombinator),
+        StringNode(Selector, "div"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -213,10 +214,10 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 17), (1, 17)),
         Token(Brace(Closing), (1, 18), (1, 18))
       |])) == [|
-        RuleStart(StyleRule),
-        Selector(".first"),
-        Selector(".second"),
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".first"),
+        StringNode(Selector, ".second"),
+        Node(RuleEnd)
       |]
     });
 
@@ -235,15 +236,15 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 29), (1, 29)),
         Token(Brace(Closing), (1, 30), (1, 30))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        FunctionStart(":not"),
-        Selector(".first"),
-        Selector(".second"),
-        FunctionEnd,
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        StringNode(FunctionStart, ":not"),
+        StringNode(Selector, ".first"),
+        StringNode(Selector, ".second"),
+        Node(FunctionEnd),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -263,16 +264,16 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 22), (1, 22)),
         Token(Brace(Closing), (1, 23), (1, 23))
       |])) == [|
-        RuleStart(StyleRule),
-        FunctionStart(":not"),
-        CompoundSelectorStart,
-        Selector(".test"),
-        FunctionStart(":not"),
-        Selector("div"),
-        FunctionEnd,
-        CompoundSelectorEnd,
-        FunctionEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(FunctionStart, ":not"),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        StringNode(FunctionStart, ":not"),
+        StringNode(Selector, "div"),
+        Node(FunctionEnd),
+        Node(CompoundSelectorEnd),
+        Node(FunctionEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -293,13 +294,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 9), (1, 9)),
         Token(Brace(Closing), (1, 10), (1, 10))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        ParentSelector,
-        ChildCombinator,
-        Selector("div"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        Node(ParentSelector),
+        Node(ChildCombinator),
+        StringNode(Selector, "div"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -313,13 +314,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 10), (1, 10)),
         Token(Brace(Closing), (1, 11), (1, 11))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        ParentSelector,
-        DoubledChildCombinator,
-        Selector("div"),
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        Node(ParentSelector),
+        Node(DoubledChildCombinator),
+        StringNode(Selector, "div"),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -358,14 +359,14 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 10), (1, 10)),
         Token(Brace(Closing), (1, 11), (1, 11))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        AttributeSelectorStart(CaseSensitive),
-        AttributeName("attr"),
-        AttributeSelectorEnd,
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        AttributeKindNode(AttributeSelectorStart, CaseSensitive),
+        StringNode(AttributeName, "attr"),
+        Node(AttributeSelectorEnd),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -379,15 +380,15 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 10), (1, 10)),
         Token(Brace(Closing), (1, 11), (1, 11))
       |])) == [|
-        RuleStart(StyleRule),
-        CompoundSelectorStart,
-        Selector(".test"),
-        SpaceCombinator,
-        AttributeSelectorStart(CaseSensitive),
-        AttributeName("abc"),
-        AttributeSelectorEnd,
-        CompoundSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        Node(CompoundSelectorStart),
+        StringNode(Selector, ".test"),
+        Node(SpaceCombinator),
+        AttributeKindNode(AttributeSelectorStart, CaseSensitive),
+        StringNode(AttributeName, "abc"),
+        Node(AttributeSelectorEnd),
+        Node(CompoundSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -404,13 +405,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 15), (1, 15)),
         Token(Brace(Closing), (1, 16), (1, 16))
       |])) == [|
-        RuleStart(StyleRule),
-        AttributeSelectorStart(CaseSensitive),
-        AttributeName("attr"),
-        AttributeOperator("="),
-        AttributeValue("\"test\""),
-        AttributeSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        AttributeKindNode(AttributeSelectorStart, CaseSensitive),
+        StringNode(AttributeName, "attr"),
+        StringNode(AttributeOperator, "="),
+        StringNode(AttributeValue, "\"test\""),
+        Node(AttributeSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -428,13 +429,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 15), (1, 15)),
         Token(Brace(Closing), (1, 16), (1, 16))
       |])) == [|
-        RuleStart(StyleRule),
-        AttributeSelectorStart(CaseSensitive),
-        AttributeName("attr"),
-        AttributeOperator("^="),
-        AttributeValue("\"test\""),
-        AttributeSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        AttributeKindNode(AttributeSelectorStart, CaseSensitive),
+        StringNode(AttributeName, "attr"),
+        StringNode(AttributeOperator, "^="),
+        StringNode(AttributeValue, "\"test\""),
+        Node(AttributeSelectorEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -453,13 +454,13 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 17), (1, 17)),
         Token(Brace(Closing), (1, 18), (1, 18))
       |])) == [|
-        RuleStart(StyleRule),
-        AttributeSelectorStart(CaseInsensitive),
-        AttributeName("attr"),
-        AttributeOperator("^="),
-        AttributeValue("\"test\""),
-        AttributeSelectorEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        AttributeKindNode(AttributeSelectorStart, CaseInsensitive),
+        StringNode(AttributeName, "attr"),
+        StringNode(AttributeOperator, "^="),
+        StringNode(AttributeValue, "\"test\""),
+        Node(AttributeSelectorEnd),
+        Node(RuleEnd)
       |];
     });
   });
@@ -476,8 +477,8 @@ describe("Parser", () => {
         Token(Word("papayawhip"), (1, 8), (1, 18)),
         Token(Semicolon, (1, 19), (1, 19))
       |])) == [|
-        Property("color"),
-        Value("papayawhip"),
+        StringNode(Property, "color"),
+        StringNode(Value, "papayawhip"),
       |];
     });
 
@@ -489,8 +490,8 @@ describe("Parser", () => {
         Token(Word("papayawhip"), (1, 12), (1, 21)),
         Token(Semicolon, (1, 22), (1, 22))
       |])) == [|
-        Property("-ms-color"),
-        Value("papayawhip"),
+        StringNode(Property, "-ms-color"),
+        StringNode(Value, "papayawhip"),
       |];
     });
 
@@ -504,8 +505,8 @@ describe("Parser", () => {
         Token(Semicolon, (1, 17), (1, 17)),
         Token(Semicolon, (1, 18), (1, 18))
       |])) == [|
-        Property("color"),
-        Value("papayawhip"),
+        StringNode(Property, "color"),
+        StringNode(Value, "papayawhip"),
       |];
     });
 
@@ -519,8 +520,8 @@ describe("Parser", () => {
         Token(Word("papayawhip"), (1, 4), (1, 13)),
         Token(Semicolon, (1, 14), (1, 14))
       |])) == [|
-        PropertyRef(inter),
-        Value("papayawhip")
+        RefNode(PropertyRef, inter),
+        StringNode(Value, "papayawhip")
       |];
     });
 
@@ -534,8 +535,8 @@ describe("Parser", () => {
         Token(Interpolation(inter), (1, 8), (1, 8)),
         Token(Semicolon, (1, 9), (1, 9))
       |])) == [|
-        Property("color"),
-        ValueRef(inter)
+        StringNode(Property, "color"),
+        RefNode(ValueRef, inter)
       |];
     });
 
@@ -549,9 +550,9 @@ describe("Parser", () => {
         Token(Word("palevioletred"), (1, 13), (1, 25)),
         Token(Semicolon, (1, 26), (1, 26))
       |])) == [|
-        Property("color"),
-        Value("papayawhip"),
-        Value("palevioletred")
+        StringNode(Property, "color"),
+        StringNode(Value, "papayawhip"),
+        StringNode(Value, "palevioletred")
       |];
     });
 
@@ -569,9 +570,9 @@ describe("Parser", () => {
         Token(Quote(Single), (1, 25), (1, 25)),
         Token(Semicolon, (1, 26), (1, 26))
       |])) == [|
-        Property("color"),
-        Value("\"hello\""),
-        Value("'world'")
+        StringNode(Property, "color"),
+        StringNode(Value, "\"hello\""),
+        StringNode(Value, "'world'")
       |];
     });
 
@@ -600,12 +601,12 @@ describe("Parser", () => {
         Token(Quote(Double), (1, 22), (1, 22)),
         Token(Semicolon, (1, 23), (1, 23))
       |])) == [|
-        Property("color"),
-        StringStart("\""),
-        Value("hello "),
-        ValueRef(inter),
-        Value(" world"),
-        StringEnd
+        StringNode(Property, "color"),
+        StringNode(StringStart, "\""),
+        StringNode(Value, "hello "),
+        RefNode(ValueRef, inter),
+        StringNode(Value, " world"),
+        Node(StringEnd)
       |];
     });
 
@@ -620,10 +621,10 @@ describe("Parser", () => {
         Token(Paren(Closing), (1, 29), (1, 29)),
         Token(Semicolon, (1, 30), (1, 30))
       |])) == [|
-        Property("width"),
-        FunctionStart("calc"),
-        Value("2 * (50% - 20px)"),
-        FunctionEnd
+        StringNode(Property, "width"),
+        StringNode(FunctionStart, "calc"),
+        StringNode(Value, "2 * (50% - 20px)"),
+        Node(FunctionEnd)
       |];
     });
 
@@ -642,14 +643,14 @@ describe("Parser", () => {
         Token(Paren(Closing), (1, 25), (1, 25)),
         Token(Semicolon, (1, 26), (1, 26))
       |])) == [|
-        Property("width"),
-        FunctionStart("calc"),
-        CompoundValueStart,
-        Value("2 * (50% - "),
-        ValueRef(inter),
-        Value(")"),
-        CompoundValueEnd,
-        FunctionEnd
+        StringNode(Property, "width"),
+        StringNode(FunctionStart, "calc"),
+        Node(CompoundValueStart),
+        StringNode(Value, "2 * (50% - "),
+        RefNode(ValueRef, inter),
+        StringNode(Value, ")"),
+        Node(CompoundValueEnd),
+        Node(FunctionEnd)
       |];
     });
 
@@ -666,10 +667,10 @@ describe("Parser", () => {
         Token(Paren(Closing), (1, 38), (1, 38)),
         Token(Semicolon, (1, 39), (1, 39))
       |])) == [|
-        Property("background-image"),
-        FunctionStart("url"),
-        Value("\"http://test.com\""),
-        FunctionEnd
+        StringNode(Property, "background-image"),
+        StringNode(FunctionStart, "url"),
+        StringNode(Value, "\"http://test.com\""),
+        Node(FunctionEnd)
       |];
     });
 
@@ -689,13 +690,13 @@ describe("Parser", () => {
         Token(Paren(Closing), (1, 39), (1, 39)),
         Token(Semicolon, (1, 40), (1, 40))
       |])) == [|
-        Property("background-image"),
-        FunctionStart("url"),
-        StringStart("\""),
-        Value("http://test.com/"),
-        ValueRef(inter),
-        StringEnd,
-        FunctionEnd
+        StringNode(Property, "background-image"),
+        StringNode(FunctionStart, "url"),
+        StringNode(StringStart, "\""),
+        StringNode(Value, "http://test.com/"),
+        RefNode(ValueRef, inter),
+        Node(StringEnd),
+        Node(FunctionEnd)
       |];
     });
 
@@ -714,12 +715,12 @@ describe("Parser", () => {
         Token(Paren(Closing), (1, 24), (1, 24)),
         Token(Semicolon, (1, 25), (1, 25))
       |])) == [|
-        Property("background-image"),
-        FunctionStart("url"),
-        StringStart("\""),
-        ValueRef(inter),
-        StringEnd,
-        FunctionEnd
+        StringNode(Property, "background-image"),
+        StringNode(FunctionStart, "url"),
+        StringNode(StringStart, "\""),
+        RefNode(ValueRef, inter),
+        Node(StringEnd),
+        Node(FunctionEnd)
       |];
     });
 
@@ -732,11 +733,11 @@ describe("Parser", () => {
         Token(Word("20px"), (1, 15), (1, 17)),
         Token(Semicolon, (1, 18), (1, 18))
       |])) == [|
-        Property("padding"),
-        CompoundValueStart,
-        Value("10px"),
-        Value("20px"),
-        CompoundValueEnd
+        StringNode(Property, "padding"),
+        Node(CompoundValueStart),
+        StringNode(Value, "10px"),
+        StringNode(Value, "20px"),
+        Node(CompoundValueEnd)
       |];
     });
 
@@ -767,9 +768,9 @@ describe("Parser", () => {
         Token(Word("papayawhip"), (2, 8), (2, 18)),
         Token(Semicolon, (2, 19), (2, 19))
       |])) == [|
-        PartialRef(inter),
-        Property("color"),
-        Value("papayawhip"),
+        RefNode(PartialRef, inter),
+        StringNode(Property, "color"),
+        StringNode(Value, "papayawhip"),
       |];
     });
 
@@ -783,10 +784,10 @@ describe("Parser", () => {
         Token(Brace(Opening), (2, 7), (2, 7)),
         Token(Brace(Closing), (2, 8), (2, 8))
       |])) == [|
-        PartialRef(inter),
-        RuleStart(StyleRule),
-        Selector(".test"),
-        RuleEnd
+        RefNode(PartialRef, inter),
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".test"),
+        Node(RuleEnd)
       |];
     });
 
@@ -800,10 +801,10 @@ describe("Parser", () => {
         Token(Interpolation(inter), (1, 8), (1, 8)),
         Token(Brace(Closing), (1, 9), (1, 9))
       |])) == [|
-        RuleStart(StyleRule),
-        Selector(".test"),
-        PartialRef(inter),
-        RuleEnd
+        RuleKindNode(RuleStart, StyleRule),
+        StringNode(Selector, ".test"),
+        RefNode(PartialRef, inter),
+        Node(RuleEnd)
       |];
     });
 
@@ -822,11 +823,11 @@ describe("Parser", () => {
         Token(Word("blue"), (2, 8), (2, 11)),
         Token(Semicolon, (2, 12), (2, 12))
       |])) == [|
-        Property("color"),
-        Value("blue"),
-        PartialRef(inter),
-        Property("color"),
-        Value("blue")
+        StringNode(Property, "color"),
+        StringNode(Value, "blue"),
+        RefNode(PartialRef, inter),
+        StringNode(Property, "color"),
+        StringNode(Value, "blue")
       |];
     });
 
@@ -842,9 +843,9 @@ describe("Parser", () => {
         Token(Word("blue"), (1, 10), (1, 13)),
         Token(Semicolon, (1, 14), (1, 14))
       |])) == [|
-        PartialRef(inter),
-        Property("color"),
-        Value("blue")
+        RefNode(PartialRef, inter),
+        StringNode(Property, "color"),
+        StringNode(Value, "blue")
       |];
     });
 
@@ -878,9 +879,9 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 12), (1, 12)),
         Token(Brace(Closing), (1, 13), (1, 13))
       |])) == [|
-        RuleStart(MediaRule),
-        Condition("all"),
-        RuleEnd
+        RuleKindNode(RuleStart, MediaRule),
+        StringNode(Condition, "all"),
+        Node(RuleEnd)
       |];
     });
 
@@ -898,16 +899,16 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 38), (1, 38)),
         Token(Brace(Closing), (1, 39), (1, 39))
       |])) == [|
-        RuleStart(MediaRule),
-        CompoundConditionStart,
-        Condition("screen"),
-        Condition("and"),
-        ConditionGroupStart,
-        Property("min-width"),
-        Value("900px"),
-        ConditionGroupEnd,
-        CompoundConditionEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, MediaRule),
+        Node(CompoundConditionStart),
+        StringNode(Condition, "screen"),
+        StringNode(Condition, "and"),
+        Node(ConditionGroupStart),
+        StringNode(Property, "min-width"),
+        StringNode(Value, "900px"),
+        Node(ConditionGroupEnd),
+        Node(CompoundConditionEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -921,10 +922,10 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 23), (1, 23)),
         Token(Brace(Closing), (1, 24), (1, 24))
       |])) == [|
-        RuleStart(MediaRule),
-        Condition("screen"),
-        Condition("print"),
-        RuleEnd
+        RuleKindNode(RuleStart, MediaRule),
+        StringNode(Condition, "screen"),
+        StringNode(Condition, "print"),
+        Node(RuleEnd)
       |];
     });
 
@@ -942,19 +943,19 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 24), (1, 24)),
         Token(Brace(Closing), (1, 25), (1, 25))
       |])) == [|
-        RuleStart(SupportsRule),
-        CompoundConditionStart,
-        Condition("not"),
-        ConditionGroupStart,
-        CompoundConditionStart,
-        Condition("not"),
-        ConditionGroupStart,
-        Condition("test"),
-        ConditionGroupEnd,
-        CompoundConditionEnd,
-        ConditionGroupEnd,
-        CompoundConditionEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, SupportsRule),
+        Node(CompoundConditionStart),
+        StringNode(Condition, "not"),
+        Node(ConditionGroupStart),
+        Node(CompoundConditionStart),
+        StringNode(Condition, "not"),
+        Node(ConditionGroupStart),
+        StringNode(Condition, "test"),
+        Node(ConditionGroupEnd),
+        Node(CompoundConditionEnd),
+        Node(ConditionGroupEnd),
+        Node(CompoundConditionEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -972,19 +973,19 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 24), (1, 24)),
         Token(Brace(Closing), (1, 25), (1, 25))
       |])) == [|
-        RuleStart(SupportsRule),
-        CompoundConditionStart,
-        Condition("not"),
-        ConditionGroupStart,
-        CompoundConditionStart,
-        Condition("not"),
-        ConditionGroupStart,
-        Condition("test"),
-        ConditionGroupEnd,
-        CompoundConditionEnd,
-        ConditionGroupEnd,
-        CompoundConditionEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, SupportsRule),
+        Node(CompoundConditionStart),
+        StringNode(Condition, "not"),
+        Node(ConditionGroupStart),
+        Node(CompoundConditionStart),
+        StringNode(Condition, "not"),
+        Node(ConditionGroupStart),
+        StringNode(Condition, "test"),
+        Node(ConditionGroupEnd),
+        Node(CompoundConditionEnd),
+        Node(ConditionGroupEnd),
+        Node(CompoundConditionEnd),
+        Node(RuleEnd)
       |];
     });
 
@@ -1001,11 +1002,11 @@ describe("Parser", () => {
         Token(Brace(Opening), (1, 20), (1, 20)),
         Token(Brace(Closing), (1, 21), (1, 21))
       |])) == [|
-        RuleStart(DocumentRule),
-        FunctionStart("url"),
-        Condition("\"test\""),
-        FunctionEnd,
-        RuleEnd
+        RuleKindNode(RuleStart, DocumentRule),
+        StringNode(FunctionStart, "url"),
+        StringNode(Condition, "\"test\""),
+        Node(FunctionEnd),
+        Node(RuleEnd)
       |];
     });
   });

--- a/__tests__/Printer.re
+++ b/__tests__/Printer.re
@@ -1,10 +1,12 @@
+open IstfNode;
+
 /* Stream type for the ParserStream */
 type printerStream = LazyStream.t(string);
 
 let printer = (s: Parser.parserStream) => {
   let indentation = ref(0);
 
-  let stringifyKind = (kind: Parser.ruleKind) : string => {
+  let stringifyKind = (kind: ruleKind) : string => {
     switch (kind) {
     | StyleRule => "STYLE_RULE"
     | CharsetRule => "CHARSET_RULE"
@@ -25,100 +27,97 @@ let printer = (s: Parser.parserStream) => {
     }
   };
 
-  let stringifyNode = (node: Parser.node) : string => {
+  let stringifyNode = (node: node) : string => {
     let indentImmediate = ref(indentation^);
     let nodeOutput = switch (node) {
-    | RuleStart(kind) => {
+    | RuleKindNode(RuleStart, kind) => {
       indentation := indentation^ + 1;
       "[RULE_START, " ++ stringifyKind(kind) ++ "]"
     }
-    | RuleEnd => {
+    | Node(RuleEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[RULE_END]"
     }
-    | RuleName(str) => "[RULE_NAME, '" ++ str ++ "']"
-    | Selector(str) => "[SELECTOR, '" ++ str ++ "']"
-    | ParentSelector => "[PARENT_SELECTOR]"
-    | UniversalSelector => "[UNIVERSAL_SELECTOR]"
-    | CompoundSelectorStart => {
+    | StringNode(Selector, str) => "[SELECTOR, '" ++ str ++ "']"
+    | Node(ParentSelector) => "[PARENT_SELECTOR]"
+    | Node(UniversalSelector) => "[UNIVERSAL_SELECTOR]"
+    | Node(CompoundSelectorStart) => {
       indentation := indentation^ + 1;
       "[COMPOUND_SELECTOR_START]"
     }
-    | CompoundSelectorEnd => {
+    | Node(CompoundSelectorEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[COMPOUND_SELECTOR_END]"
     }
-    | SpaceCombinator => "[SPACE_COMBINATOR]"
-    | DoubledChildCombinator => "[DOUBLED_CHILD_COMBINATOR]"
-    | ChildCombinator => "[CHILD_COMBINATOR]"
-    | NextSiblingCombinator => "[NEXT_SIBLING_COMBINATOR]"
-    | SubsequentSiblingCombinator => "[SUBSEQUENT_SIBLING_COMBINATOR]"
-    | Property(str) => "[PROPERTY, '" ++ str ++ "']"
-    | Value(str) => "[VALUE, '" ++ str ++ "']"
-    | CompoundValueStart => {
+    | Node(SpaceCombinator) => "[SPACE_COMBINATOR]"
+    | Node(DoubledChildCombinator) => "[DOUBLED_CHILD_COMBINATOR]"
+    | Node(ChildCombinator) => "[CHILD_COMBINATOR]"
+    | Node(NextSiblingCombinator) => "[NEXT_SIBLING_COMBINATOR]"
+    | Node(SubsequentSiblingCombinator) => "[SUBSEQUENT_SIBLING_COMBINATOR]"
+    | StringNode(Property, str) => "[PROPERTY, '" ++ str ++ "']"
+    | StringNode(Value, str) => "[VALUE, '" ++ str ++ "']"
+    | Node(CompoundValueStart) => {
       indentation := indentation^ + 1;
       "[COMPOUND_VALUE_START]"
     }
-    | CompoundValueEnd => {
+    | Node(CompoundValueEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[COMPOUND_VALUE_END]"
     }
-    | Condition(str) => "[CONDITION, '" ++ str ++ "']"
-    | FunctionStart(str) => {
+    | StringNode(Condition, str) => "[CONDITION, '" ++ str ++ "']"
+    | StringNode(FunctionStart, str) => {
       indentation := indentation^ + 1;
       "[FUNCTION_START, '" ++ str ++ "']"
     }
-    | FunctionEnd => {
+    | Node(FunctionEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[FUNCTION_END]"
     }
-    | AnimationName(str) => "[ANIMATION_NAME, '" ++ str ++ "']"
-    | SelectorRef(_) => "[SELECTOR_REF, ref]"
-    | PropertyRef(_) => "[PROPERTY_REF, ref]"
-    | ValueRef(_) => "[VALUE_REF, ref]"
-    | PartialRef(_) => "[PARTIAL_REF, ref]"
-    | StringStart(str) => {
+    | RefNode(SelectorRef, _) => "[SELECTOR_REF, ref]"
+    | RefNode(PropertyRef, _) => "[PROPERTY_REF, ref]"
+    | RefNode(ValueRef, _) => "[VALUE_REF, ref]"
+    | RefNode(PartialRef, _) => "[PARTIAL_REF, ref]"
+    | StringNode(StringStart, str) => {
       indentation := indentation^ + 1;
       "[STRING_START, '" ++ str ++ "']"
     }
-    | StringEnd => {
+    | Node(StringEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[STRING_END]"
     }
-    | AttributeSelectorStart(kind) =>
-      "[ATTRIBUTE_SELECTOR_START, " ++ string_of_int(Parser.attributeSelectorKindToJs(kind)) ++ "]"
-    | AttributeSelectorEnd => "[ATTRIBUTE_SELECTOR_END]"
-    | AttributeName(str) => "[ATTRIBUTE_NAME, '" ++ str ++ "']"
-    | AttributeNameRef(_) => "[ATTRIBUTE_NAME_REF, ref]"
-    | AttributeOperator(str) => "[ATTRIBUTE_OPERATOR, '" ++ str ++ "']"
-    | AttributeValue(str) => "[ATTRIBUTE_VALUE, '" ++ str ++ "']"
-    | AttributeValueRef(_) => "[ATTRIBUTE_VALUE_REF, ref]"
-    | ConditionRef(_) => "[CONDITION_REF, ref]"
-    | CompoundConditionStart => {
+    | AttributeKindNode(AttributeSelectorStart, kind) =>
+      "[ATTRIBUTE_SELECTOR_START, " ++ string_of_int(attributeSelectorKindToJs(kind)) ++ "]"
+    | Node(AttributeSelectorEnd) => "[ATTRIBUTE_SELECTOR_END]"
+    | StringNode(AttributeName, str) => "[ATTRIBUTE_NAME, '" ++ str ++ "']"
+    | RefNode(AttributeNameRef, _) => "[ATTRIBUTE_NAME_REF, ref]"
+    | StringNode(AttributeOperator, str) => "[ATTRIBUTE_OPERATOR, '" ++ str ++ "']"
+    | StringNode(AttributeValue, str) => "[ATTRIBUTE_VALUE, '" ++ str ++ "']"
+    | RefNode(AttributeValueRef, _) => "[ATTRIBUTE_VALUE_REF, ref]"
+    | RefNode(ConditionRef, _) => "[CONDITION_REF, ref]"
+    | Node(CompoundConditionStart) => {
       indentation := indentation^ + 1;
       "[COMPOUND_CONDITION_START]"
     }
-    | CompoundConditionEnd => {
+    | Node(CompoundConditionEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[COMPOUND_CONDITION_END]"
     }
-    | ConditionGroupStart => {
+    | Node(ConditionGroupStart) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[CONDITION_GROUP_START]"
     }
-    | ConditionGroupEnd => {
+    | Node(ConditionGroupEnd) => {
       indentation := indentation^ - 1;
       indentImmediate := indentImmediate^ - 1;
       "[CONDITION_GROUP_END]"
     }
-    | EOF => "/eof"
     };
 
     let indent = String.make(indentImmediate^ * 2, ' ');

--- a/src/IstfNode.re
+++ b/src/IstfNode.re
@@ -1,0 +1,149 @@
+open Common;
+
+/* an error raised by the converter when accepting raw (JS) nodes */
+exception ConversionError(string);
+
+/* For RuleStart kinds */
+[@bs.deriving jsConverter]
+type ruleKind =
+  [@bs.as 1] | StyleRule /* CSSOM */
+  [@bs.as 2] | CharsetRule /* CSSOM */
+  [@bs.as 3] | ImportRule /* CSSOM */
+  [@bs.as 4] | MediaRule /* CSSOM */
+  [@bs.as 5] | FontFaceRule /* CSSOM */
+  [@bs.as 6] | PageRule /* CSSOM */
+  [@bs.as 7] | KeyframesRule /* CSS 3 Animations */
+  [@bs.as 8] | KeyframeRule /* CSS 3 Animations */
+  [@bs.as 9] | MarginRule /* CSSOM */
+  [@bs.as 10] | NamespaceRule /* CSSOM */
+  [@bs.as 11] | CounterStyleRule /* CSS 3 Lists */
+  [@bs.as 12] | SupportsRule /* CSS 3 Conditional */
+  [@bs.as 13] | DocumentRule /* CSS 3 Conditional */
+  [@bs.as 14] | FontFeatureValuesRule /* CSS 3 Fonts */
+  [@bs.as 15] | ViewportRule /* CSS Device Adapt */
+  [@bs.as 16] | RegionStyleRule; /* Proposed for CSS 3 Regions */
+
+/* For attribute selector kinds */
+[@bs.deriving jsConverter]
+type attributeSelectorKind =
+  [@bs.as 1] | CaseSensitive
+  [@bs.as 2] | CaseInsensitive;
+
+/* A node is represented by its (ISTF) type and potentially a value */
+
+[@bs.deriving jsConverter]
+type nodeKind_ruleKind =
+  [@bs.as 0] | RuleStart;
+
+[@bs.deriving jsConverter]
+type nodeKind_attributeKind =
+  [@bs.as 26] | AttributeSelectorStart;
+
+[@bs.deriving jsConverter]
+type nodeKind_ref =
+  [@bs.as 20] | SelectorRef
+  [@bs.as 21] | PropertyRef
+  [@bs.as 22] | ValueRef
+  [@bs.as 23] | PartialRef
+  [@bs.as 29] | AttributeNameRef
+  [@bs.as 32] | AttributeValueRef
+  [@bs.as 34] | ConditionRef;
+
+[@bs.deriving jsConverter]
+type nodeKind_string =
+  [@bs.as 3] | Selector
+  [@bs.as 13] | Property
+  [@bs.as 14] | Value
+  [@bs.as 17] | FunctionStart
+  [@bs.as 24] | StringStart
+  [@bs.as 28] | AttributeName
+  [@bs.as 30] | AttributeOperator
+  [@bs.as 31] | AttributeValue
+  [@bs.as 33] | Condition;
+
+[@bs.deriving jsConverter]
+type nodeKind_empty =
+  [@bs.as 1] | RuleEnd
+  [@bs.as 4] | ParentSelector
+  [@bs.as 5] | UniversalSelector
+  [@bs.as 6] | CompoundSelectorStart
+  [@bs.as 7] | CompoundSelectorEnd
+  [@bs.as 8] | SpaceCombinator
+  [@bs.as 9] | DoubledChildCombinator
+  [@bs.as 10] | ChildCombinator
+  [@bs.as 11] | NextSiblingCombinator
+  [@bs.as 12] | SubsequentSiblingCombinator
+  [@bs.as 15] | CompoundValueStart
+  [@bs.as 16] | CompoundValueEnd
+  [@bs.as 18] | FunctionEnd
+  [@bs.as 25] | StringEnd
+  [@bs.as 27] | AttributeSelectorEnd
+  [@bs.as 35] | CompoundConditionStart
+  [@bs.as 36] | CompoundConditionEnd
+  [@bs.as 37] | ConditionGroupStart
+  [@bs.as 38] | ConditionGroupEnd;
+
+type node =
+  | RuleKindNode(nodeKind_ruleKind, ruleKind)
+  | AttributeKindNode(nodeKind_attributeKind, attributeSelectorKind)
+  | RefNode(nodeKind_ref, interpolation)
+  | StringNode(nodeKind_string, string)
+  | Node(nodeKind_empty);
+
+type rawNodePayload;
+
+external intToRawNodePayload: (int) => rawNodePayload = "%identity";
+external refToRawNodePayload: (interpolation) => rawNodePayload = "%identity";
+external stringToRawNodePayload: (string) => rawNodePayload = "%identity";
+
+let emptyRawNodePayload: [@bs] (int) => (int, rawNodePayload) = [%raw {|
+  function (x) { return [x]; }
+|}];
+
+/* convert IstfNode.t to JS format */
+let nodeToJs = (node: node) : (int, rawNodePayload) => {
+  switch (node) {
+  | RuleKindNode(kind, x) => (
+    nodeKind_ruleKindToJs(kind),
+    intToRawNodePayload(ruleKindToJs(x))
+  )
+
+  | AttributeKindNode(kind, x) => (
+    nodeKind_attributeKindToJs(kind),
+    intToRawNodePayload(attributeSelectorKindToJs(x))
+  )
+
+  | RefNode(kind, x) => (
+    nodeKind_refToJs(kind),
+    refToRawNodePayload(x)
+  )
+
+  | StringNode(kind, x) => (
+    nodeKind_stringToJs(kind),
+    stringToRawNodePayload(x)
+  )
+
+  | Node(kind) => [@bs] emptyRawNodePayload(nodeKind_emptyToJs(kind))
+  }
+};
+
+let nodeFromJs = (nodeRaw: (int, rawNodePayload)) : node => {
+  let (nodeKind, _) = nodeRaw;
+
+  let tuple = (
+    nodeKind_ruleKindFromJs(nodeKind),
+    nodeKind_attributeKindFromJs(nodeKind),
+    nodeKind_refFromJs(nodeKind),
+    nodeKind_stringFromJs(nodeKind),
+    nodeKind_emptyFromJs(nodeKind)
+  );
+
+  switch (tuple) {
+  | (Some(x), _, _, _, _) => RuleKindNode(x, [%raw {| nodeRaw[1] |}])
+  | (_, Some(x), _, _, _) => AttributeKindNode(x, [%raw {| nodeRaw[1] |}])
+  | (_, _, Some(x), _, _) => RefNode(x, [%raw {| nodeRaw[1] |}])
+  | (_, _, _, Some(x), _) => StringNode(x, [%raw {| nodeRaw[1] |}])
+  | (_, _, _, _, Some(x)) => Node(x)
+  | _ => raise(ConversionError("Serialised node data was not recognised"))
+  }
+};

--- a/src/IstfNode.re
+++ b/src/IstfNode.re
@@ -88,7 +88,8 @@ type node =
   | AttributeKindNode(nodeKind_attributeKind, attributeSelectorKind)
   | RefNode(nodeKind_ref, interpolation)
   | StringNode(nodeKind_string, string)
-  | Node(nodeKind_empty);
+  | Node(nodeKind_empty)
+  | EOF;
 
 type rawNodePayload;
 
@@ -124,6 +125,7 @@ let nodeToJs = (node: node) : (int, rawNodePayload) => {
   )
 
   | Node(kind) => [@bs] emptyRawNodePayload(nodeKind_emptyToJs(kind))
+  | EOF => [@bs] emptyRawNodePayload(0)
   }
 };
 

--- a/src/Main.re
+++ b/src/Main.re
@@ -5,7 +5,7 @@ let tokenise = (strings: array(string), interpolations: array(interpolation)) : 
     |> Lexer.lexer
     |> LazyStream.toArray;
 
-let parse = (strings: array(string), interpolations: array(interpolation)) : array(Output.outputNode) =>
+let parse = (strings: array(string), interpolations: array(interpolation)) : array((int, IstfNode.rawNodePayload)) =>
   Input.input(strings, interpolations)
     |> Lexer.lexer
     |> Parser.parser

--- a/src/Output.re
+++ b/src/Output.re
@@ -1,71 +1,12 @@
-open Common;
-
-/* an error raised by the parser contains a message and a line number */
-exception OutputError(string);
-
-type outputNode =
-  | EmptyMarker(int)
-  | IntMarker(int, int)
-  | StringMarker(int, string)
-  | RefMarker(int, interpolation);
+open IstfNode;
 
 /* Stream type for the OutputStream */
-type outputStream = LazyStream.t(outputNode);
+type outputStream = LazyStream.t((int, rawNodePayload));
 
-let output = (s: Parser.parserStream) => {
-  let serialiseRuleKind = (kind: Parser.ruleKind) : int => Parser.ruleKindToJs(kind);
-
-  let serialiseAttributeSelectorKind = (kind: Parser.attributeSelectorKind) : int =>
-    Parser.attributeSelectorKindToJs(kind);
-
-  let serialiseNode = (n: Parser.node) : outputNode => {
-    switch (n) {
-    | RuleStart(ruleKind) => IntMarker(0, serialiseRuleKind(ruleKind))
-    | RuleEnd => EmptyMarker(1)
-    | RuleName(str) => StringMarker(2, str)
-    | Selector(str) => StringMarker(3, str)
-    | ParentSelector => EmptyMarker(4)
-    | UniversalSelector => EmptyMarker(5)
-    | CompoundSelectorStart => EmptyMarker(6)
-    | CompoundSelectorEnd => EmptyMarker(7)
-    | SpaceCombinator => EmptyMarker(8)
-    | DoubledChildCombinator => EmptyMarker(9)
-    | ChildCombinator => EmptyMarker(10)
-    | NextSiblingCombinator => EmptyMarker(11)
-    | SubsequentSiblingCombinator => EmptyMarker(12)
-    | Property(str) => StringMarker(13, str)
-    | Value(str) => StringMarker(14, str)
-    | CompoundValueStart => EmptyMarker(15)
-    | CompoundValueEnd => EmptyMarker(16)
-    | Condition(str) => StringMarker(17, str)
-    | FunctionStart(str) => StringMarker(18, str)
-    | FunctionEnd => EmptyMarker(19)
-    | AnimationName(str) => StringMarker(20, str)
-    | SelectorRef(x) => RefMarker(21, x)
-    | PropertyRef(x) => RefMarker(22, x)
-    | ValueRef(x) => RefMarker(23, x)
-    | PartialRef(x) => RefMarker(24, x)
-    | StringStart(str) => StringMarker(25, str)
-    | StringEnd => EmptyMarker(26)
-    | AttributeSelectorStart(kind) => IntMarker(27, serialiseAttributeSelectorKind(kind))
-    | AttributeSelectorEnd => EmptyMarker(28)
-    | AttributeName(str) => StringMarker(29, str)
-    | AttributeNameRef(x) => RefMarker(30, x)
-    | AttributeOperator(str) => StringMarker(31, str)
-    | AttributeValue(str) => StringMarker(32, str)
-    | AttributeValueRef(x) => RefMarker(33, x)
-    | ConditionRef(x) => RefMarker(34, x)
-    | CompoundConditionStart => EmptyMarker(35)
-    | CompoundConditionEnd => EmptyMarker(36)
-    | ConditionGroupStart => EmptyMarker(37)
-    | ConditionGroupEnd => EmptyMarker(38)
-    | EOF => raise(OutputError("Unexpected Parser node"))
-    }
-  };
-
-  let next: [@bs] (unit => option(outputNode)) = [@bs] (() => {
+let output = (s: Parser.parserStream) : outputStream => {
+  let next: [@bs] (unit => option((int, rawNodePayload))) = [@bs] (() => {
     switch (LazyStream.next(s)) {
-    | Some(node) => Some(serialiseNode(node))
+    | Some(node) => Some(nodeToJs(node))
     | None => None
     }
   });


### PR DESCRIPTION
- Improve JS node format to be consistent (always array)
- Adds explicit **and safe** to/from JS conversion
- Refactors Reason's node types to be more similar to what the output is
- Moves node types to separate `IstfNode` module